### PR TITLE
🐛 번역 로직 에러 수정

### DIFF
--- a/FrontEnd/src/api/TranslatedText.jsx
+++ b/FrontEnd/src/api/TranslatedText.jsx
@@ -50,7 +50,7 @@ const TranslatedText = ({ text }) => {
       };
   
       translate();
-    }, [language]);
+    }, [language, text]);
     
     return <>{translated}</>;
   };

--- a/FrontEnd/src/pages/DetailsPage.jsx
+++ b/FrontEnd/src/pages/DetailsPage.jsx
@@ -23,6 +23,7 @@ export default function DetailsPage() {
         if (detailRes?.isSuccess) {
           setNewsDetail(detailRes.data.newsDetail);
           setRecentNewsList(detailRes.data.recentNewsList);
+          console.log(detailRes.data.newsDetail);
         }
 
         // 뉴스 요약 요청


### PR DESCRIPTION
구글 번역 로직에서 useEffect에 text가 바뀔때 재렌더링을 안해주는 문제해결