### PR TITLE
✨ [FEAT/#63] Google OAuth2 + JWT 로그인/로그아웃 연동

### DIFF
--- a/FrontEnd/src/App.jsx
+++ b/FrontEnd/src/App.jsx
@@ -1,14 +1,17 @@
 import { BrowserRouter } from 'react-router-dom';
 import Routes from './router/Routers';
 import { LanguageProvider } from './util/LanguageContext.jsx';
+import { AuthProvider } from './util/AuthContext.jsx';
 
 function App() {
   return (
-    <LanguageProvider>
-      <BrowserRouter>
-        <Routes />
-      </BrowserRouter>
-    </LanguageProvider>
+    <AuthProvider>
+      <LanguageProvider>
+        <BrowserRouter>
+          <Routes />
+        </BrowserRouter>
+      </LanguageProvider>
+    </AuthProvider>
   )
 }
 

--- a/FrontEnd/src/api/authAPI.js
+++ b/FrontEnd/src/api/authAPI.js
@@ -1,0 +1,13 @@
+import axios from "axios";
+
+// 인증 포함 axios 인스턴스
+export const authAPI = axios.create();
+
+// 요청 interceptor: 토큰 자동 주입
+authAPI.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});

--- a/FrontEnd/src/components/commons/header/Header.jsx
+++ b/FrontEnd/src/components/commons/header/Header.jsx
@@ -2,6 +2,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import styles from "./Header.module.css";
 import Logo from "../../../assets/logo/logo.png";
 import { useLanguage } from "../../../util/LanguageContext.jsx";
+import { useAuth } from "../../../util/AuthContext.jsx";
 import TranslatedText from "../../../api/TranslatedText.jsx";
 
 //import GoogleTranslate from "../../../api/GoogleTranslate";
@@ -12,6 +13,11 @@ export default function Header() {
 
   // 전역으로 언어를 선택하는 함수
   const { language, setLanguage } = useLanguage();
+  const { isLoggedIn, user, logout } = useAuth();
+
+  const handleLogin = () => {
+    window.location.href = "/oauth2/authorization/google";
+  };
 
   // 현재 경로가 "/"이면 흰색 테마 적용
   const isHome = location.pathname === "/" || location.pathname === "/intro";
@@ -52,6 +58,22 @@ export default function Header() {
         >
           <TranslatedText text="서비스 소개" />
         </p>
+        {/* 로그인/로그아웃 */}
+        <div className={styles.authContainer}>
+          {isLoggedIn ? (
+            <>
+              <span className={styles.nickname}>{user?.nickname ?? ""}</span>
+              <button onClick={logout} className={styles.authButton}>
+                <TranslatedText text="로그아웃" />
+              </button>
+            </>
+          ) : (
+            <button onClick={handleLogin} className={styles.authButton}>
+              <TranslatedText text="로그인" />
+            </button>
+          )}
+        </div>
+
         <div
           className={`${styles.languageToggle} ${
             isHome ? styles.whiteText : styles.blackText

--- a/FrontEnd/src/components/commons/header/Header.module.css
+++ b/FrontEnd/src/components/commons/header/Header.module.css
@@ -175,3 +175,30 @@
 .logoContainer{
   cursor: pointer;
 }
+
+.authContainer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.nickname {
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.authButton {
+  background: transparent;
+  border: 1px solid currentColor;
+  color: currentColor;
+  padding: 5px 14px;
+  font-size: 14px;
+  font-weight: bold;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.authButton:hover {
+  opacity: 0.7;
+}

--- a/FrontEnd/src/pages/OAuthCallbackPage.jsx
+++ b/FrontEnd/src/pages/OAuthCallbackPage.jsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "../util/AuthContext";
+
+export default function OAuthCallbackPage() {
+  const navigate = useNavigate();
+  const { login } = useAuth();
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+
+    if (token) {
+      login(token);
+      navigate("/main", { replace: true });
+    } else {
+      // 토큰 없으면 메인으로
+      navigate("/", { replace: true });
+    }
+  }, []);
+
+  return (
+    <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh" }}>
+      <p>로그인 처리 중...</p>
+    </div>
+  );
+}

--- a/FrontEnd/src/router/Routers.jsx
+++ b/FrontEnd/src/router/Routers.jsx
@@ -7,6 +7,7 @@ import SearchPage from "../pages/SearchPage"
 import DetailsPage from '../pages/DetailsPage';
 import ScrapPage from '../pages/ScrapPage';
 import IntroPage from "../pages/IntroPage";
+import OAuthCallbackPage from "../pages/OAuthCallbackPage";
 
 // layouts
 import MainLayout from '../layouts/MainLayout';
@@ -23,6 +24,8 @@ export default function Routes() {
                 <Route path='scrap' element={<ScrapPage />} />
                 <Route path='intro' element={<IntroPage />} />
             </Route>
+            {/* OAuth2 로그인 콜백 - MainLayout 밖에 위치 */}
+            <Route path='/oauth/callback' element={<OAuthCallbackPage />} />
         </ReactRouters>
     )
 }

--- a/FrontEnd/src/util/AuthContext.jsx
+++ b/FrontEnd/src/util/AuthContext.jsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useState, useEffect } from "react";
+import { authAPI } from "../api/authAPI";
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [token, setToken] = useState(localStorage.getItem("token") || null);
+  const [user, setUser] = useState(null);
+
+  // 토큰이 있으면 내 정보 조회
+  useEffect(() => {
+    if (token) {
+      authAPI.get("/api/user/me")
+        .then((res) => setUser(res.data.data))
+        .catch(() => {
+          // 토큰 만료 등 오류 시 로그아웃 처리
+          logout();
+        });
+    }
+  }, [token]);
+
+  const login = (newToken) => {
+    localStorage.setItem("token", newToken);
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    localStorage.removeItem("token");
+    setToken(null);
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout, isLoggedIn: !!token }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export function useAuth() {
+  return useContext(AuthContext);
+}


### PR DESCRIPTION
## 📌 작업 내용
Google OAuth2 로그인 후 JWT 토큰을 발급받아 저장하고,
인증 필요 API 요청에 자동으로 토큰을 포함시키는 인증 흐름 구현

- `AuthContext.jsx` - 전역 인증 상태 관리 (토큰, 유저 정보, 로그인/로그아웃)
- `authAPI.js` - axios 인스턴스 + `Authorization` 헤더 자동 주입 interceptor
- `OAuthCallbackPage.jsx` - URL 쿼리스트링에서 token 추출 → localStorage 저장 → `/main` 이동
- `Routers.jsx` - `/oauth/callback` 라우트 추가
- `App.jsx` - `AuthProvider` 최상위 래핑
- `Header.jsx` - 로그인 버튼 / 닉네임 + 로그아웃 버튼 표시
- `.env` (BE) - `OAUTH2_REDIRECT_URI` FE 콜백 주소로 수정

## ✅ 체크리스트
- [x] 로컬 확인 완료
- [x] BE 연동 확인 완료 (OAuth2 로그인 → 콜백 → /main 이동 동작 확인)

## 🔗 관련 이슈
Closes #63 