### PR TITLE
feat: 기사 목록/상세 BE 연동 및 번역 캐시, 요약 로딩 개선

### DIFF
--- a/FrontEnd/src/App.css
+++ b/FrontEnd/src/App.css
@@ -1,42 +1,5 @@
 #root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  margin: 0;
+  padding: 0;
+  width: 100%;
 }

--- a/FrontEnd/src/api/TranslatedText.jsx
+++ b/FrontEnd/src/api/TranslatedText.jsx
@@ -7,52 +7,80 @@ const decodeHTMLEntities = (text) => {
     const textarea = document.createElement("textarea");
     textarea.innerHTML = text;
     return textarea.value;
-  };
+};
+
+// sessionStorage 기반 번역 캐시 (세션 내 동일 텍스트+언어 재호출 방지)
+const getCacheKey = (text, lang) => `translation::${lang}::${text}`;
+
+const getCache = (text, lang) => {
+    try {
+        return sessionStorage.getItem(getCacheKey(text, lang));
+    } catch {
+        return null;
+    }
+};
+
+const setCache = (text, lang, result) => {
+    try {
+        sessionStorage.setItem(getCacheKey(text, lang), result);
+    } catch {
+        // sessionStorage 용량 초과 시 무시
+    }
+};
 
 const TranslatedText = ({ text }) => {
-    const { language } = useLanguage(); // 토글에 설정한 언어에 따라 언어 바뀜
+    const { language } = useLanguage();
     const [translated, setTranslated] = useState("");
-  
+
     useEffect(() => {
-      const translate = async () => {
-        if (!text) return;
+        const translate = async () => {
+            if (!text) return;
 
-        // 특수문자 대체
-        const cleanedText = text
-          .replace(/’/g, "'")   // 스마트 따옴표 → 일반 따옴표
-          .replace(/…/g, "...") // 줄임표 기호 → ...
-          .replace(/[“”]/g, '"'); // 쌍따옴표도 처리
+            // 특수문자 대체
+            const cleanedText = text
+                .replace(/\u2018/g, "'")
+                .replace(/\u2026/g, "...")
+                .replace(/[\u201C\u201D]/g, '"');
 
-        try {
-            const response = await axios.post(
-                "https://translation.googleapis.com/language/translate/v2",
-                {
-                  q: cleanedText,
-                  target: language,
-                },
-                {
-                  params: {
-                    key: import.meta.env.VITE_GOOGLE_API_KEY,
-                  },
-                  headers: {
-                    "Content-Type": "application/json",
-                  },
-                }
-              );
+            // 캐시 히트 시 API 호출 없이 반환
+            const cached = getCache(cleanedText, language);
+            if (cached !== null) {
+                setTranslated(cached);
+                return;
+            }
 
-            const rawTranslated = response.data.data.translations[0].translatedText;
-            const decodedTranslated = decodeHTMLEntities(rawTranslated); // 👉 디코딩 적용
-            setTranslated(decodedTranslated);
-        } catch (error) {
-          console.error("Translation Error:", error);
-          setTranslated("(번역 실패)");
-        }
-      };
-  
-      translate();
+            try {
+                const response = await axios.post(
+                    "https://translation.googleapis.com/language/translate/v2",
+                    {
+                        q: cleanedText,
+                        target: language,
+                    },
+                    {
+                        params: {
+                            key: import.meta.env.VITE_GOOGLE_API_KEY,
+                        },
+                        headers: {
+                            "Content-Type": "application/json",
+                        },
+                    }
+                );
+
+                const rawTranslated = response.data.data.translations[0].translatedText;
+                const decodedTranslated = decodeHTMLEntities(rawTranslated);
+
+                setCache(cleanedText, language, decodedTranslated);
+                setTranslated(decodedTranslated);
+            } catch (error) {
+                console.error("Translation Error:", error);
+                setTranslated("(번역 실패)");
+            }
+        };
+
+        translate();
     }, [language, text]);
-    
+
     return <>{translated}</>;
-  };
-  
-  export default TranslatedText;
+};
+
+export default TranslatedText;

--- a/FrontEnd/src/components/commons/footer/Footer.module.css
+++ b/FrontEnd/src/components/commons/footer/Footer.module.css
@@ -3,28 +3,28 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
-  padding: 20px 0;
+  padding: 20px 40px;
   background: #f8f9fa;
   text-align: center;
   font-size: 14px;
   color: #6c757d;
   border-top: 1px solid #ddd;
-  /* margin-top: 40px; */
+  box-sizing: border-box;
 }
 
 .footerContainer h2 {
   font-size: 24px;
   font-weight: bold;
-  margin-left: 5%;
+  flex-shrink: 0;
 }
 
 .footer {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    flex: 1;
-    margin-left: 5%;
-  }
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  flex: 1;
+  margin-left: 5%;
+}
 
 .links {
   display: flex;
@@ -44,4 +44,36 @@
 .copyright {
   font-size: 12px;
   color: #868e96;
+}
+
+@media (max-width: 768px) {
+  .footerContainer {
+    flex-direction: column;
+    align-items: flex-start;
+    text-align: left;
+    gap: 16px;
+    padding: 20px 24px;
+  }
+
+  .footerContainer h2 {
+    margin-left: 0;
+  }
+
+  .footer {
+    margin-left: 0;
+    width: 100%;
+  }
+
+  .links {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 10px;
+    margin-bottom: 12px;
+  }
+
+  .copyright {
+    font-size: 11px;
+    line-height: 1.6;
+    text-align: left;
+  }
 }

--- a/FrontEnd/src/components/commons/header/Header.jsx
+++ b/FrontEnd/src/components/commons/header/Header.jsx
@@ -1,17 +1,16 @@
 import { useNavigate, useLocation } from "react-router-dom";
+import { useState } from "react";
 import styles from "./Header.module.css";
 import Logo from "../../../assets/logo/logo.png";
 import { useLanguage } from "../../../util/LanguageContext.jsx";
 import { useAuth } from "../../../util/AuthContext.jsx";
 import TranslatedText from "../../../api/TranslatedText.jsx";
 
-//import GoogleTranslate from "../../../api/GoogleTranslate";
-
 export default function Header() {
   const navigate = useNavigate();
   const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
 
-  // 전역으로 언어를 선택하는 함수
   const { language, setLanguage } = useLanguage();
   const { isLoggedIn, user, logout } = useAuth();
 
@@ -19,12 +18,18 @@ export default function Header() {
     window.location.href = "/oauth2/authorization/google";
   };
 
-  // 현재 경로가 "/"이면 흰색 테마 적용
   const isHome = location.pathname === "/" || location.pathname === "/intro";
 
-  function handleMainPageClick() {
-    navigate("/main");
-  }
+  const navItems = [
+    { label: "메인페이지", path: "/main" },
+    { label: "마이스크랩", path: "/scrap" },
+    { label: "서비스 소개", path: "/intro" },
+  ];
+
+  const handleNav = (path) => {
+    navigate(path);
+    setMenuOpen(false);
+  };
 
   return (
     <div className={styles.headerContainer}>
@@ -33,6 +38,7 @@ export default function Header() {
           isHome ? styles.whiteText : styles.blackText
         } ${isHome ? styles.blackBackground : styles.whiteBackground}`}
       >
+        {/* 로고 */}
         <div className={styles.logoContainer}>
           <img
             src={Logo}
@@ -40,50 +46,38 @@ export default function Header() {
             onClick={() => navigate("/")}
           />
         </div>
-        <p
-          onClick={handleMainPageClick}
-          className={location.pathname === "/main" ? styles.active : ""}
-        >
-          <TranslatedText text="메인페이지" />
-        </p>
-        <p
-          onClick={() => navigate("/scrap")}
-          className={location.pathname === "/scrap" ? styles.active : ""}
-        >
-          <TranslatedText text="마이스크랩" />
-        </p>
-        <p
-          onClick={() => navigate("/intro")}
-          className={location.pathname === "/intro" ? styles.active : ""}
-        >
-          <TranslatedText text="서비스 소개" />
-        </p>
-        {/* 로그인/로그아웃 */}
-        <div className={styles.authContainer}>
-          {isLoggedIn ? (
-            <>
-              <span className={styles.nickname}>{user?.nickname ?? ""}</span>
-              <button onClick={logout} className={styles.authButton}>
-                <TranslatedText text="로그아웃" />
-              </button>
-            </>
-          ) : (
-            <button onClick={handleLogin} className={styles.authButton}>
-              <TranslatedText text="로그인" />
-            </button>
-          )}
-        </div>
 
-        <div
-          className={`${styles.languageToggle} ${
-            isHome ? styles.whiteText : styles.blackText
-          }`}
-        >
-          {/* 언어선택 */}
-          <select
-            value={language}
-            onChange={(e) => setLanguage(e.target.value)}
-          >
+        {/* 데스크탑 네비게이션 */}
+        <nav className={styles.desktopNav}>
+          {navItems.map(({ label, path }) => (
+            <p
+              key={path}
+              onClick={() => handleNav(path)}
+              className={location.pathname === path ? styles.active : ""}
+            >
+              <TranslatedText text={label} />
+            </p>
+          ))}
+        </nav>
+
+        {/* 데스크탑 우측 영역 */}
+        <div className={styles.desktopRight}>
+          <div className={styles.authContainer}>
+            {isLoggedIn ? (
+              <>
+                <span className={styles.nickname}>{user?.nickname ?? ""}</span>
+                <button onClick={logout} className={styles.authButton}>
+                  <TranslatedText text="로그아웃" />
+                </button>
+              </>
+            ) : (
+              <button onClick={handleLogin} className={styles.authButton}>
+                <TranslatedText text="로그인" />
+              </button>
+            )}
+          </div>
+          <div className={`${styles.languageToggle} ${isHome ? styles.whiteText : styles.blackText}`}>
+            <select value={language} onChange={(e) => setLanguage(e.target.value)}>
             <option value="ko">한국어</option>
             <option value="en">English</option>
             <option value="ja">
@@ -164,6 +158,64 @@ export default function Header() {
             <option value="de">
               Deutsch (<TranslatedText text="독일어" />)
             </option>
+          </select>
+          </div>
+        </div>
+
+        {/* 햄버거 버튼 (모바일) */}
+        <button
+          className={`${styles.hamburger} ${menuOpen ? styles.hamburgerOpen : ""}`}
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-label="메뉴 열기"
+        >
+          <span />
+          <span />
+          <span />
+        </button>
+      </div>
+
+      {/* 오버레이 (메뉴 외 영역 클릭 시 닫힘) */}
+      <div
+        className={`${styles.overlay} ${menuOpen ? styles.overlayVisible : ""}`}
+        onClick={() => setMenuOpen(false)}
+      />
+
+      {/* 모바일 사이드 메뉴 (우측 슬라이드) */}
+      <div className={`${styles.mobileMenu} ${menuOpen ? styles.mobileMenuOpen : ""}`}>
+        {navItems.map(({ label, path }) => (
+          <p
+            key={path}
+            onClick={() => handleNav(path)}
+            className={`${styles.mobileMenuItem} ${location.pathname === path ? styles.mobileMenuActive : ""}`}
+          >
+            <TranslatedText text={label} />
+          </p>
+        ))}
+        <div className={styles.mobileMenuAuth}>
+          {isLoggedIn ? (
+            <>
+              <span className={styles.mobileNickname}>{user?.nickname ?? ""}</span>
+              <button onClick={() => { logout(); setMenuOpen(false); }} className={styles.authButton}>
+                <TranslatedText text="로그아웃" />
+              </button>
+            </>
+          ) : (
+            <button onClick={handleLogin} className={styles.authButton}>
+              <TranslatedText text="로그인" />
+            </button>
+          )}
+        </div>
+        <div className={styles.mobileMenuLang}>
+          <select value={language} onChange={(e) => setLanguage(e.target.value)}>
+            <option value="ko">한국어</option>
+            <option value="en">English</option>
+            <option value="ja">日本語</option>
+            <option value="zh-CN">中文 (간체)</option>
+            <option value="zh-TW">繁體中文 (번체)</option>
+            <option value="fr">Français</option>
+            <option value="es">Español</option>
+            <option value="de">Deutsch</option>
+            <option value="ru">Русский</option>
           </select>
         </div>
       </div>

--- a/FrontEnd/src/components/commons/header/Header.module.css
+++ b/FrontEnd/src/components/commons/header/Header.module.css
@@ -2,13 +2,13 @@
   position: fixed;
   top: 0px;
   width: 100%;
-  z-index: 2;
+  z-index: 102;
 }
 
 .header {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   align-items: center;
-  justify-content: space-between;
   width: 100%;
   padding: 5px 40px;
   position: relative;
@@ -22,9 +22,10 @@
   cursor: pointer;
   position: relative;
   display: inline-block;
-  padding-bottom: 3px;
+  padding: 6px 14px;
   font-weight: bold;
-  transition: color 0.3s ease-in-out, font-weight 0.3s ease-in-out;
+  border-radius: 8px;
+  transition: color 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
 }
 
 .whiteBackground {
@@ -48,31 +49,17 @@
   color: black;
 }
 
+/* 호버 시 골드 컬러 + 살짝 위로 + 반투명 배경 */
 .whiteText p:hover {
-  color: rgba(255, 255, 255, 0.8);
+  color: #f0c040;
+  background-color: rgba(240, 192, 64, 0.12);
+  transform: translateY(-2px);
 }
 
 .blackText p:hover {
-  color: rgba(51, 51, 51, 0.8);
-}
-
-.header p::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  bottom: 0;
-  margin-bottom: -4px;
-  width: 100%;
-  height: 3px;
-  background-color: currentColor;
-  transform: scaleX(0);
-  transform-origin: right;
-  transition: transform 0.3s ease-in-out;
-}
-
-.header p:hover::after {
-  transform: scaleX(1);
-  transform-origin: left;
+  color: #b8860b;
+  background-color: rgba(184, 134, 11, 0.1);
+  transform: translateY(-2px);
 }
 
 .whiteText {
@@ -83,32 +70,10 @@
   color: black;
 }
 
-.header::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  width: 95%;
-  height: 1.5px;
-  background-color: currentColor;
-  transform: translateX(-50%);
-}
-
-.whiteText .header::after {
-  background-color: white;
-}
-
-.blackText .header::after {
-  background-color: black;
-}
 
 .languageToggle {
   position: relative;
-  margin-left: 100px;
-  margin-right: 20px;
-
   border-radius: 20px;
-
 }
 
 .languageToggle select {
@@ -153,18 +118,9 @@
 
 .active {
   font-weight: bold;
-  position: relative;
-}
-
-.active::after {
-  content: "";
-  position: absolute;
-  bottom: -5px;
-  left: 50%;
-  width: 100%;
-  height: 3px;
-  background-color: currentColor;
-  transform: translateX(-50%);
+  color: #f0c040 !important;
+  background-color: rgba(240, 192, 64, 0.15) !important;
+  border-radius: 8px;
 }
 
 .image{
@@ -174,6 +130,8 @@
 
 .logoContainer{
   cursor: pointer;
+  display: flex;
+  align-items: center;
 }
 
 .authContainer {
@@ -201,4 +159,190 @@
 
 .authButton:hover {
   opacity: 0.7;
+}
+
+/* 데스크탑 네비게이션 - 정중앙 */
+.desktopNav {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 우측 영역 - 우측 정렬 */
+.desktopRight {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* 햄버거 버튼 - 기본 숨김 */
+.hamburger {
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 6px;
+  z-index: 101;
+  position: relative;
+}
+
+.hamburger span {
+  display: block;
+  width: 24px;
+  height: 2px;
+  background-color: currentColor;
+  border-radius: 2px;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  transform-origin: center;
+}
+
+/* 햄버거 → X 애니메이션 */
+.hamburgerOpen span:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.hamburgerOpen span:nth-child(2) {
+  opacity: 0;
+  transform: scaleX(0);
+}
+.hamburgerOpen span:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+/* 모바일 사이드 메뉴 (우측에서 슬라이드) */
+.mobileMenu {
+  display: none;
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: 260px;
+  flex-direction: column;
+  background-color: rgba(30, 30, 30, 0.97);
+  color: white;
+  z-index: 100;
+  padding-top: 70px;
+  box-shadow: -4px 0 20px rgba(0, 0, 0, 0.3);
+  transform: translateX(100%);
+  transition: transform 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  will-change: transform;
+  backface-visibility: hidden;
+}
+
+.mobileMenuOpen {
+  transform: translateX(0);
+  transition: transform 0.35s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+/* 오버레이 (메뉴 외 영역 클릭 시 닫힘용) */
+.overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 99;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+  will-change: opacity;
+}
+
+.overlayVisible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+
+.mobileMenuItem {
+  padding: 16px 28px;
+  margin: 0;
+  font-size: 16px;
+  font-weight: bold;
+  color: white;
+  cursor: pointer;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  transition: background-color 0.2s ease;
+}
+
+.mobileMenuItem:hover {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.mobileMenuActive {
+  color: #f0c040;
+  font-weight: 900;
+}
+
+.mobileMenuAuth {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 28px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.mobileNickname {
+  font-size: 15px;
+  font-weight: bold;
+  color: white;
+}
+
+.mobileMenuLang {
+  padding: 16px 28px;
+}
+
+.mobileMenuLang select {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+  cursor: pointer;
+}
+
+.mobileMenuLang select option {
+  background: #1e1e1e;
+  color: white;
+}
+
+/* 반응형: 768px 이하에서 햄버거 표시, 데스크탑 요소 숨김 */
+@media (max-width: 768px) {
+  .desktopNav {
+    display: none;
+  }
+
+  .desktopRight {
+    display: none;
+  }
+
+  .hamburger {
+    display: flex;
+    color: inherit;
+  }
+
+  .mobileMenu {
+    display: flex;
+  }
+
+  .overlay {
+    display: block;
+    pointer-events: none;
+  }
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px 16px;
+  }
+
+  .image {
+    width: 140px;
+    height: 32px;
+  }
 }

--- a/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
+++ b/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
@@ -6,7 +6,7 @@ import { MutatingDots } from "react-loader-spinner";
 //컴포넌트 변경
 import TranslatedText from "../../api/TranslatedText.jsx";
 
-export default function ArticleDetail({ id, newsDetail, content, isLoading }) {
+export default function ArticleDetail({ id, newsDetail, content, isLoading, isSummaryLoading }) {
   const articleId = Number(id);
   const { title, author, sourceName, publishedAt, viewCount, urlToImage } =
     newsDetail;
@@ -58,8 +58,8 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading }) {
         {sourceName} - {author}
       </p>
       <img src={urlToImage} alt="기사 이미지" className={styles.image} />
-      {/* 기사 요약내용 */}
-      {isLoading ? (
+      {/* 기사 요약내용 - 상세 정보와 독립적으로 로딩 */}
+      {isSummaryLoading ? (
          <MutatingDots 
            height={100} 
            width={100} 
@@ -69,8 +69,10 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading }) {
            ariaLabel="mutating-dots-loading"
            visible={true}
          />
-         ) : (
+         ) : content ? (
            <p className={styles.content}><TranslatedText text={content}/></p>
+         ) : (
+           <p className={styles.content}>요약 정보를 불러올 수 없습니다.</p>
          )
        }
     </div>

--- a/FrontEnd/src/components/intro/bottom/IntroBottom.module.css
+++ b/FrontEnd/src/components/intro/bottom/IntroBottom.module.css
@@ -1,14 +1,14 @@
 /* 전체 영역 */
 .introPage--container{
-    /* 레이아웃 */
     width: 100%;
-    height: 2200px;
+    height: auto;
+    min-height: fit-content;
     display: flex;
     flex-direction: column;
     align-items: center;
     padding-top: 15%;
+    padding-bottom: 80px;
 
-    /* 스타일 */
     background-color: white;
     color: black;
 }
@@ -99,18 +99,69 @@
 /* 이미지 그리디 */
 .gridContainer {
     display: grid;
-    grid-template-columns: repeat(3, 1fr); /* 3열 */
-    grid-template-rows: repeat(2, 1fr);    /* 2행 */
-    gap: 5%; /* 이미지 간격 */
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(2, 1fr);
+    gap: 5%;
     width: 90%;
 
     & img{
         width: 100%;
-        aspect-ratio: 1/1; /* 정사각형 유지 */
+        aspect-ratio: 1/1;
         object-fit: cover;
         border-radius: 8px;
         box-shadow: 8px 8px 16px rgba(0, 0, 0, 0.2);
-
     }
-  }
+}
+
+@media (max-width: 768px) {
+    .introPage--container {
+        height: auto;
+        padding-top: 60px;
+        padding-bottom: 60px;
+    }
+
+    .introPage--team {
+        flex-direction: column;
+        gap: 32px;
+        margin-bottom: 48px;
+
+        & .contentDiv {
+            margin-left: 5%;
+            margin-right: 5%;
+
+            & p {
+                font-size: 32px;
+                width: auto;
+            }
+
+            & span {
+                font-size: 17px;
+                width: 100%;
+            }
+        }
+
+        & .imgDiv {
+            padding: 0 5%;
+
+            & img {
+                width: 100%;
+                min-width: unset;
+            }
+        }
+    }
+
+    .introPage--works {
+        & p {
+            font-size: 32px;
+            width: auto;
+            margin-left: 5%;
+        }
+    }
+
+    .gridContainer {
+        grid-template-columns: repeat(2, 1fr);
+        width: 90%;
+        gap: 4%;
+    }
+}
   

--- a/FrontEnd/src/components/intro/top/IntroTop.jsx
+++ b/FrontEnd/src/components/intro/top/IntroTop.jsx
@@ -21,27 +21,29 @@ import summarizeImg from "../../../assets/summarizeImg.png";
 
 
 export default function IntroTop(){
-    // 전역 현재 사용자 언어
     const { language } = useLanguage();
 
-    //상단 위치
     const { ref: topRef, inView: topInView } = useInView({
         threshold: 0.8,
     });
 
-    //사용자의 스크롤 y축 값
     const { scrollY } = useScroll();
 
-    // OurService 고정 및 visible여부
-    const [isVisible, setIsVisible] = useState(false);
-    // 번역 visible여부
-    const [isTranslateVisible, setIsTranslateVisible] = useState(false);
-    // 요약 visible여부
-    const [isSummarizeVisible, setIsSummarizeVisible] = useState(false);
-    // 질문 visible여부
-    const [isAskVisible, setIsAskVisible] = useState(false);
-    // 스크랩 visible여부
-    const [isScrapVisible, setIsScrapVisible] = useState(false);
+    const [isMobile, setIsMobile] = useState(window.innerWidth <= 768);
+
+    useEffect(() => {
+        const handleResize = () => setIsMobile(window.innerWidth <= 768);
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    const [visibility, setVisibility] = useState({
+        service: false,
+        translate: false,
+        summarize: false,
+        ask: false,
+        scrap: false,
+    });
 
     // 서비스 소개 변수
     const [serviceText1, setServiceText1] = useState("사용자 언어에 맞는<br/>실시간 번역");
@@ -75,26 +77,30 @@ export default function IntroTop(){
     }, [language])
 
     useEffect(() => {
-        const unsubscribe = scrollY.on("change", () => {
-            const y = scrollY.get();
-            console.log(y);
+        let rafId = null;
 
-            //our service
-            setIsVisible(y >= pinStart && y <= pinEnd);
-            //translate
-            setIsTranslateVisible(y >= pinTranslateStart && y <= pinTranslateStart+500);
-            //summarize
-            setIsSummarizeVisible(y >= pinSummarizeStart && y <= pinSummarizeStart+500);
-            //ask
-            setIsAskVisible(y >= pinAskStart && y <= pinAskStart+500);
-            //scrap
-            setIsScrapVisible(y >= pinScrapStart && y <= pinScrapStart+500);
+        const unsubscribe = scrollY.on("change", (y) => {
+            if (rafId) return;
+            rafId = requestAnimationFrame(() => {
+                setVisibility({
+                    service:   y >= pinStart          && y <= pinEnd,
+                    translate: y >= pinTranslateStart && y <= pinTranslateStart + 500,
+                    summarize: y >= pinSummarizeStart && y <= pinSummarizeStart + 500,
+                    ask:       y >= pinAskStart       && y <= pinAskStart       + 500,
+                    scrap:     y >= pinScrapStart     && y <= pinScrapStart     + 500,
+                });
+                rafId = null;
+            });
         });
-        return () => unsubscribe();
-      }, [scrollY]);
+
+        return () => {
+            unsubscribe();
+            if (rafId) cancelAnimationFrame(rafId);
+        };
+    }, [scrollY]);
 
     return(
-        <div className={styles['introPage--container']}>
+        <div className={`${styles['introPage--container']} ${isMobile ? styles['introPage--containerMobile'] : ''}`}>
             {/* 설명 페이지 상단 */}
             <motion.div
                 ref={topRef}
@@ -111,47 +117,49 @@ export default function IntroTop(){
 
 
             {/* 설명 페이지 서비스 소개 */}
-            {/* Our Service 고정 섹션 */}
-            <motion.div
-                className={styles["introPage--service"]}
-                initial={{ opacity: 0, y: 20 }}
-                animate={isVisible ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
-                transition={{ duration: 0.6, ease: "easeOut" }}
-            >
-                <p>Our Service</p>
-            </motion.div>
+            {isMobile ? (
+                <div className={styles["introPage--serviceMobile"]}>
+                    <p>Our Service</p>
+                </div>
+            ) : (
+                <motion.div
+                    className={styles["introPage--service"]}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={visibility.service ? { opacity: 1, y: 0 } : { opacity: 0, y: 20 }}
+                    transition={{ duration: 0.6, ease: "easeOut" }}
+                >
+                    <p>Our Service</p>
+                </motion.div>
+            )}
 
             {/* 내용 */}
-            {/* 번역 소개 애니메이션 */}
             <IntroTopAnimation
-                isVisible={isTranslateVisible}
+                isVisible={visibility.translate}
                 title="TRANSLATE"
                 description={serviceText1}
                 imgSrc={translateImg}
+                isMobile={isMobile}
             />
-
-            {/* 요약 소개 애니메이션 */}
             <IntroTopAnimation
-                isVisible={isSummarizeVisible}
+                isVisible={visibility.summarize}
                 title="SUMMARIZE"
                 description={serviceText2}
                 imgSrc={summarizeImg}
+                isMobile={isMobile}
             />
-
-            {/* 질문 소개 애니메이션 */}
             <IntroTopAnimation
-                isVisible={isAskVisible}
+                isVisible={visibility.ask}
                 title="QUESTION"
                 description={serviceText3}
                 imgSrc={askImg}
+                isMobile={isMobile}
             />
-
-            {/* 스크랩 소개 애니메이션 */}
             <IntroTopAnimation
-                isVisible={isScrapVisible}
+                isVisible={visibility.scrap}
                 title="SCRAP"
                 description={serviceText4}
                 imgSrc={scrapImg}
+                isMobile={isMobile}
             />
         </div>
     );

--- a/FrontEnd/src/components/intro/top/IntroTop.module.css
+++ b/FrontEnd/src/components/intro/top/IntroTop.module.css
@@ -13,7 +13,6 @@
 
 /* top영역 We Are~ */
 .introPage--top{
-    /* 레이아웃 */
     width: 100%;
     display: flex;
     flex-direction: column;
@@ -22,30 +21,39 @@
     margin-bottom: 500px;
 
     & p{
-        /* 레이아웃 */
         display: flex;
         justify-content: center;
         width: 160px;
-
-        /* 스타일 */
         font-size: 35px;
         font-weight: 500;
-
-        /* 밑줄 */
         border-bottom: 2px solid;
         padding-bottom: 4px;
     }
 
     & span{
-        /* 레이아웃 */
         display: flex;
         text-align: center;
         width: auto;
         margin-top: 30px;
-
-        /* 스타일 */
         font-size: 25px;
         font-weight: 400;
+    }
+}
+
+@media (max-width: 768px) {
+    .introPage--top {
+        margin-bottom: 60px;
+        padding: 0 20px;
+
+        & p {
+            font-size: 26px;
+        }
+
+        & span {
+            font-size: 17px;
+            text-align: center;
+            line-height: 1.7;
+        }
     }
 }
 
@@ -78,9 +86,74 @@
   }
 
 
+/* 모바일 전용 컨테이너 */
+.introPage--containerMobile {
+    height: auto !important;
+}
+
+/* 모바일 전용 Our Service 정적 헤딩 */
+.introPage--serviceMobile {
+    width: 90%;
+    display: flex;
+    justify-content: center;
+    margin-bottom: 16px;
+
+    & p {
+        font-size: 32px;
+        font-weight: 500;
+        color: white;
+        border-bottom: 2px solid white;
+        padding-bottom: 4px;
+    }
+}
+
+/* 모바일 전용 서비스 카드 */
+.introPage--mainMobile {
+    width: 90%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+    padding: 48px 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+
+    & .contentDiv {
+        width: 100%;
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+
+        & p {
+            font-size: 32px;
+            font-weight: 500;
+            margin: 0;
+        }
+
+        & span {
+            font-size: 18px;
+            font-weight: 400;
+            line-height: 1.6;
+        }
+    }
+
+    & .imgDiv {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+
+        & img {
+            width: 100%;
+            max-width: 400px;
+            object-fit: cover;
+            border-radius: 8px;
+            box-shadow: 8px 8px 16px rgba(0, 0, 0, 0.3);
+        }
+    }
+}
+
 /* 서비스 소개 메인 내용 */
 .introPage--main {
-    /* 레이아웃 */
     position: fixed;
     top: 300px;
     left: 0px;
@@ -93,6 +166,8 @@
     opacity: 0;
     pointer-events: none;
     gap: 10%;
+    will-change: transform, opacity;
+    backface-visibility: hidden;
 
     & .contentDiv{
         flex: 5; /* 전체 영역의 50% */

--- a/FrontEnd/src/components/intro/top/IntroTopAnimation.jsx
+++ b/FrontEnd/src/components/intro/top/IntroTopAnimation.jsx
@@ -1,16 +1,31 @@
 import { motion } from "framer-motion";
 import styles from "./IntroTop.module.css";
 
-export default function IntroAnimation({ isVisible, title, description, imgSrc }) {
+export default function IntroAnimation({ isVisible, title, description, imgSrc, isMobile }) {
+
+    if (isMobile) {
+        return (
+            <div className={styles["introPage--mainMobile"]}>
+                <div className={styles["contentDiv"]}>
+                    <p>{title}</p>
+                    <span dangerouslySetInnerHTML={{ __html: description }} />
+                </div>
+                <div className={styles["imgDiv"]}>
+                    <img src={imgSrc} alt="로딩중..." />
+                </div>
+            </div>
+        );
+    }
+
     return (
       <motion.div
         className={styles["introPage--main"]}
         initial={{ opacity: 0, y: 30 }}
-        animate={
-            isVisible 
-            ? { opacity: 1, y: 0 } 
-            : { opacity: 0, y: -30 }}
-        transition={{ duration: 0.8, ease: "easeInOut" }}
+        animate={isVisible ? { opacity: 1, y: 0 } : { opacity: 0, y: -20 }}
+        transition={{
+            opacity: { duration: 0.45, ease: "easeOut" },
+            y:       { duration: 0.5,  ease: [0.25, 0.46, 0.45, 0.94] },
+        }}
       >
         <div className={styles["contentDiv"]}>
           <p>{title}</p>

--- a/FrontEnd/src/components/mainPage/News.module.css
+++ b/FrontEnd/src/components/mainPage/News.module.css
@@ -1,7 +1,6 @@
 
 /* Main News */
 .MainNews--container{
-    
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -12,9 +11,22 @@
 }
 
 .MainNews--Newscontainer{
-    width: 75vw;
+    width: min(75vw, 1200px);
     height: max-content;
     margin: 50px 0;
+}
+
+@media (max-width: 900px) {
+    .MainNews--Newscontainer {
+        width: 90vw;
+    }
+}
+
+@media (max-width: 480px) {
+    .MainNews--Newscontainer {
+        width: 95vw;
+        margin: 24px 0;
+    }
 }
 
 .MainNews--titleContainer{
@@ -23,45 +35,55 @@
 }
 
 .MainNews--title{
-    font-size: 2vw;
+    font-size: clamp(18px, 2vw, 28px);
     margin:0;
 }
 
-
-
 .MainNews--News {
     display: grid;
-    grid-template-columns: repeat(3, 1fr); /* 3열 그리드 설정 */
-    gap: 10px;
-    justify-content: center; /* 카드들을 가로로 중앙 정렬 */
-    align-items: center; /* 세로 정렬 */
-    min-height: 50vh; /* 프로젝트가 없을 때도 공간 확보 */
-    padding: 0px 10px;
-  }
-  
-  @media (max-width: 768px) {
-    /* 화면 가로 크기가 768px 이하일 때 */
-    .MainNews--News {
-      grid-template-columns: repeat(2, 1fr); /* 2열로 변경 */
-    }
-  }
+    grid-template-columns: repeat(3, 1fr);
+    gap: 12px;
+    align-items: start;
+    padding: 0px 4px;
+}
 
-  .MainNews--News__latest {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr); /* 3열 그리드 설정 */
-    gap: 10px;
-    justify-content: center; /* 카드들을 가로로 중앙 정렬 */
-    align-items: center; /* 세로 정렬 */
-    min-height: 32vh; /* 프로젝트가 없을 때도 공간 확보 */
-    padding: 0px 10px;
-  }
-  
-  @media (max-width: 768px) {
-    /* 화면 가로 크기가 768px 이하일 때 */
-    .MainNews--News__latest {
-      grid-template-columns: repeat(2, 1fr); /* 2열로 변경 */
+@media (max-width: 900px) {
+    .MainNews--News {
+        grid-template-columns: repeat(2, 1fr);
     }
-  }
+}
+
+@media (max-width: 480px) {
+    .MainNews--News {
+        grid-template-columns: repeat(1, 1fr);
+    }
+}
+
+.MainNews--News__latest {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 10px;
+    align-items: start;
+    padding: 0px 4px;
+}
+
+@media (max-width: 1024px) {
+    .MainNews--News__latest {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (max-width: 768px) {
+    .MainNews--News__latest {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 480px) {
+    .MainNews--News__latest {
+        grid-template-columns: repeat(1, 1fr);
+    }
+}
 
 .MainNews--pages{
     width: 100%;

--- a/FrontEnd/src/components/mainPage/SearchContainer.module.css
+++ b/FrontEnd/src/components/mainPage/SearchContainer.module.css
@@ -26,16 +26,33 @@
     width: 88%;
     height: 100%;
     padding: 0px 15px;
-    border: 1px solid #565656;
+    border: 2px solid #565656;
     border-radius: 11px;
     box-shadow: 3px 3px 5px #a7a7a7;
     margin-right: 20px;
+    transition: border-color 0.25s ease, box-shadow 0.25s ease;
 }
+
+.searchContainer--searchInputContainer:hover {
+    border-color: #f0c040;
+    box-shadow: 0 0 0 3px rgba(240, 192, 64, 0.15), 3px 3px 5px #a7a7a7;
+}
+
+.searchContainer--searchInputContainer:focus-within {
+    border-color: #f0c040;
+    box-shadow: 0 0 0 4px rgba(240, 192, 64, 0.2), 3px 3px 8px #a7a7a7;
+}
+
 .input-icon{
     stroke-width: 2.5;
     width: 30px;
     height: 30px;
     color: #565656;
+    transition: color 0.25s ease;
+}
+
+.searchContainer--searchInputContainer:focus-within .input-icon {
+    color: #f0c040;
 }
 
 .searchContainer--Input{
@@ -62,15 +79,25 @@
     border-radius: 12px;
     outline: none;
     box-shadow: 3px 3px 5px #a7a7a7;
+    transition: background-color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
 }
 
 .searchContainer--searchButton:hover {
     background-color: #000000;
+    transform: translateY(-1px);
+    box-shadow: 3px 5px 10px #888;
+}
+
+.searchContainer--searchButton:active {
+    transform: translateY(0px);
+    box-shadow: 2px 2px 4px #a7a7a7;
 }
 
 .searchContainer--searchButton:disabled {
     background-color: #ccc;
-    cursor:default;
+    cursor: default;
+    transform: none;
+    box-shadow: none;
 }
 
 

--- a/FrontEnd/src/components/newsCard/BasicNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/BasicNewsCard.jsx
@@ -31,7 +31,7 @@ export default function BasicNewsCard({id, press, title, summary, image, year, m
                 <div className={styled['basicNewsCard--imageBorder']}>
                     <div 
                         className={styled['basicNewsCard--image']}
-                        style={{ backgroundImage: `url(${image})` }} 
+                        style={image ? { backgroundImage: `url(${image})` } : {}} 
                     ></div>
                 </div>
                 

--- a/FrontEnd/src/components/newsCard/HotNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/HotNewsCard.jsx
@@ -14,7 +14,7 @@ export default function HotNewsCard({ id, press, title, summary, image, year, mo
         <div className={styled['hotNewsCard--container']} onClick={handleClickNewsCard}>
             <div 
                 className={styled['hotNewsCard--image']}
-                style={{ backgroundImage: `url(${image})` }} 
+                style={image ? { backgroundImage: `url(${image})` } : {}} 
             ></div>
             <div className={styled['hotNewsCard--contents']}>
                 <div className={styled['hotNewsCard--contents__letterContainer']}>

--- a/FrontEnd/src/components/newsCard/NewsCard.module.css
+++ b/FrontEnd/src/components/newsCard/NewsCard.module.css
@@ -4,10 +4,10 @@
     flex-direction: column;
     border: 1px solid rgb(231, 231, 231);
     border-radius: 5px;
-    width: 24vw;
-    height: 32vh;;
-    position: relative; /* 위치 지정 */
-    overflow: hidden; /* 자식 요소가 컨테이너 밖으로 나가지 않게 제한 */
+    width: 100%;
+    aspect-ratio: 3 / 2;
+    position: relative;
+    overflow: hidden;
     cursor: pointer;
 }
 
@@ -71,10 +71,10 @@
 }
 
 .hotNewsCard--image{
-    width: 22.3avw;
+    width: 100%;
     height: 70%;
     border-radius: 5px 5px 0 0;
-    background-image: url('/economy.png');
+    background-image: linear-gradient(135deg, #d0d0d0 0%, #e8e8e8 50%, #c8c8c8 100%);
     background-size: cover;
     background-position: center center;
     transition: filter 0.3s ease;
@@ -96,13 +96,12 @@
 .basicNewsCard--container{
     display: flex;
     flex-direction: row;
-
     background-color: white;
     border: 1px solid rgb(238, 238, 238);
     border-radius: 3px;
-    width: 18vw;
-    height: 14vh;;
-    position: relative; /* 위치 지정 */
+    width: 100%;
+    height: 110px;
+    position: relative;
     overflow: hidden;
     transition: background-color 0.3s ease, filter 0.3s ease;
     cursor: pointer;
@@ -111,7 +110,8 @@
 
 
 .basicNewsCard--contents{
-    width: 9.5vw;
+    flex: 1;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -165,8 +165,9 @@
 }
 
 .basicNewsCard--imageContainer{
-    width: 7vw;
-    height: 98%;
+    width: 100px;
+    flex-shrink: 0;
+    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -187,10 +188,10 @@
     height: 100%;
     width: 100%;
     border-radius: 5px;
-    background-image: url('/food.png');
+    background-image: linear-gradient(135deg, #d0d0d0 0%, #e8e8e8 50%, #c8c8c8 100%);
     background-size: cover;
     background-position: center center;
-    transition: transform 0.3s ease-in-out;  /* 부드러운 확대 효과 */
+    transition: transform 0.3s ease-in-out;
 }
 
 /* 호버 시 배경 이미지 확대 */
@@ -209,8 +210,8 @@
     background-color: white;
     border: 1px solid rgb(238, 238, 238);
     border-radius: 3px;
-    width: 37vw;
-    height: 18vh;
+    width: 100%;
+    height: 140px;
     overflow: hidden;
     transition: background-color 0.3s ease, filter 0.3s ease;
     cursor: pointer;
@@ -223,7 +224,8 @@
 
 
 .searchNewsCard--contents{
-    width: 21.5vw;
+    flex: 1;
+    min-width: 0;
     display: flex;
     flex-direction: column;
     justify-content: space-between;
@@ -268,8 +270,9 @@
 }
 
 .searchNewsCard--imageContainer{
-    width: 13vw;
-    height: 98%;
+    width: 160px;
+    flex-shrink: 0;
+    height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
@@ -279,8 +282,8 @@
 .searchNewsCard--image{
     height: 80%;
     width: 90%;
-    border-radius: 15px;
-    background-image: url('/america.png');
+    border-radius: 10px;
+    background-image: linear-gradient(135deg, #d0d0d0 0%, #e8e8e8 50%, #c8c8c8 100%);
     background-size: cover;
     background-position: center center;
 }
@@ -324,10 +327,10 @@
     flex-direction: column;
     border: 1px solid rgb(231, 231, 231);
     border-radius: 5px;
-    width: 24vw;
-    height: 32vh;;
-    position: relative; /* 위치 지정 */
-    overflow: hidden; /* 자식 요소가 컨테이너 밖으로 나가지 않게 제한 */
+    width: 100%;
+    aspect-ratio: 3 / 2;
+    position: relative;
+    overflow: hidden;
     cursor: pointer;
 }
 
@@ -391,10 +394,10 @@
 }
 
 .ScrapNewsCard--image{
-    width: 22.3avw;
+    width: 100%;
     height: 70%;
     border-radius: 5px 5px 0 0;
-    background-image: url('/economy.png');
+    background-image: linear-gradient(135deg, #d0d0d0 0%, #e8e8e8 50%, #c8c8c8 100%);
     background-size: cover;
     background-position: center center;
     transition: filter 0.3s ease;

--- a/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
@@ -32,7 +32,7 @@ export default function ScrapNewsCard({ id, press, title, summary, image, year, 
         <div className={styled['ScrapNewsCard--container']} onClick={handleClickNewsCard}>
             <div 
                 className={styled['ScrapNewsCard--image']}
-                style={{ backgroundImage: `url(${image})` }} 
+                style={image ? { backgroundImage: `url(${image})` } : {}} 
             ></div>
             <div className={styled['ScrapNewsCard--contents']}>
                 <div className={styled['ScrapNewsCard--contents__letterContainer']}>

--- a/FrontEnd/src/index.css
+++ b/FrontEnd/src/index.css
@@ -15,8 +15,6 @@
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }

--- a/FrontEnd/src/pages/DetailsPage.jsx
+++ b/FrontEnd/src/pages/DetailsPage.jsx
@@ -7,39 +7,46 @@ import Sidebar from "../components/detailsPage/Sidebar";
 import Chatbot from "../components/detailsPage/Chatbot";
 
 export default function DetailsPage() {
-  const { id } = useParams(); // URL에서 기사 ID 가져오기
+  const { id } = useParams();
   const [newsDetail, setNewsDetail] = useState("");
   const [recentNewsList, setRecentNewsList] = useState([]);
   const [content, setContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
+  const [isSummaryLoading, setIsSummaryLoading] = useState(true);
 
   useEffect(() => {
-    const fetchData = async () => {
+    const fetchDetail = async () => {
       setIsLoading(true);
-
       try {
-        // 먼저 뉴스 상세 요청
         const detailRes = await getNewsDetails(id);
         if (detailRes?.isSuccess) {
           setNewsDetail(detailRes.data.newsDetail);
           setRecentNewsList(detailRes.data.recentNewsList);
-          // console.log(detailRes.data.newsDetail);
         }
+      } catch (error) {
+        console.error("상세 정보 로딩 실패:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-        // 뉴스 요약 요청
+    const fetchSummary = async () => {
+      setIsSummaryLoading(true);
+      try {
         const summaryRes = await getNewsDetailsSummary(id);
         if (summaryRes && typeof summaryRes.data === "string") {
           setContent(summaryRes.data);
         }
-        setIsLoading(false);
-
       } catch (error) {
-        console.error("Error fetching data:", error);
-      } 
+        console.error("요약 로딩 실패:", error);
+      } finally {
+        setIsSummaryLoading(false);
+      }
     };
 
     if (id) {
-      fetchData();
+      fetchDetail();
+      fetchSummary();
     }
   }, [id]);
 
@@ -52,6 +59,7 @@ export default function DetailsPage() {
             newsDetail={newsDetail} 
             content={content} 
             isLoading={isLoading}
+            isSummaryLoading={isSummaryLoading}
             />
           <Chatbot articleId={id} />
         </div>

--- a/FrontEnd/src/pages/DetailsPage.module.css
+++ b/FrontEnd/src/pages/DetailsPage.module.css
@@ -2,23 +2,38 @@
     display: flex;
     flex-direction: column;
     margin: 0 auto;
+    max-width: 1200px;
+    width: 90vw;
     gap: 20px;
     box-sizing: border-box;
+    padding: 20px 0 60px;
 }
 
 .content {
     display: flex;
-    gap: 20px;
+    gap: 24px;
 }
 
 .article {
     flex: 2;
+    min-width: 0;
     display: flex;
     flex-direction: column;
 }
 
 .sidebar {
     flex: 1;
+    min-width: 220px;
+    max-width: 320px;
+}
+
+@media (max-width: 900px) {
+    .content {
+        flex-direction: column;
+    }
+    .sidebar {
+        max-width: 100%;
+    }
 }
 
 .loadingWrapper {


### PR DESCRIPTION
## 작업 내용
- VITE_APP_API 환경변수 추가로 기사 목록 API 연동 (최신순 / 인기순)
- 상세 페이지 API 연동 (기사 상세 정보, 요약)
- 요약 로딩을 상세 정보와 분리 → 상세 정보 먼저 표시 후 요약 별도 스피너
- 요약 실패 시 "요약 정보를 불러올 수 없습니다" fallback 처리
- TranslatedText sessionStorage 캐시 추가 (동일 텍스트 재번역 방지)

## BE 버그픽스 (함께 반영)
- ArticleService, DetailService @Transactional 누락 → LazyInitializationException 수정
- 인기뉴스 날짜 필터 2일 → 30일로 조정 (로컬 테스트 환경 대응)
- Gemini 모델 gemini-2.5-flash 복원 + 타임아웃 30s → 90s 조정


### style: 헤더/레이아웃 구조 개선
- 헤더 grid 3등분으로 로고/네비/우측 균등 배치
- 네비 호버 골드 컬러 + 살짝 위로 올라오는 효과
- 햄버거 메뉴 슬라이드 애니메이션 개선 (cubic-bezier)
- App.css Vite 잔여 코드 제거, body flex 중앙정렬 제거
- footer 모바일 반응형 추가


### style: 카드/검색/인트로 UI 개선
- 뉴스 카드 썸네일 null 시 회색 그라데이션 fallback
- 뉴스 카드 고정 vw → grid 반응형 전환
- 상세 페이지 모바일 반응형 (900px 이하 사이드바 하단)
- 검색창 호버/포커스 골드 테두리 + 글로우 효과
- 인트로 스크롤 애니메이션 RAF 최적화 및 모바일 정적 레이아웃 분기
- IntroBottom 하단 빈 공간 제거

## 관련 이슈
- close #65