### PR TITLE
[FEAT/#67] AI 챗봇 SSE 질의 연동 및 UX 개선

### DIFF
--- a/FrontEnd/src/api/detailsAPI.js
+++ b/FrontEnd/src/api/detailsAPI.js
@@ -20,31 +20,34 @@ export const getNewsDetailsSummary = async (articleId) => {
     }
 };
 
-export const getNewsDetailsAsk = (articleId, question, onMessage, onComplete, onError) => {
-    const eventSource = new EventSource(
-        `${import.meta.env.VITE_APP_API}/api/ai/${articleId}/ask?question=${encodeURIComponent(question)}`
-    );
+export const getNewsDetailsAsk = (articleId, question, onMessage, onComplete, onError, token = null) => {
+    let url = `${import.meta.env.VITE_APP_API}/api/ai/${articleId}/ask?question=${encodeURIComponent(question)}`;
+    // EventSource는 커스텀 헤더 미지원 → 로그인 시 쿼리 파라미터로 토큰 전달 (BE 인증 + 히스토리 저장)
+    if (token) {
+        url += `&token=${encodeURIComponent(token)}`;
+    }
 
-    let previousText = ""; // 이전까지 받은 전체 데이터 저장
+    const eventSource = new EventSource(url);
+
+    let previousText = "";
 
     eventSource.onmessage = (event) => {
-        const newText = event.data; // 서버에서 받은 전체 문장
-        const newChunk = newText.slice(previousText.length); // 기존 데이터와 비교해 새로운 부분만 추출
-        previousText = newText; // 기존 데이터를 최신 상태로 업데이트
-
-        onMessage(newChunk); // 새 글자만 추가
+        const newText = event.data;
+        const newChunk = newText.slice(previousText.length);
+        previousText = newText;
+        onMessage(newChunk);
     };
 
     eventSource.onerror = (error) => {
         console.error("SSE 연결 오류:", error);
         eventSource.close();
-        onError(error);
+        if (onError) onError(error);
     };
 
     eventSource.addEventListener("end", () => {
         eventSource.close();
-        onComplete();
+        if (onComplete) onComplete();
     });
 
-    return () => eventSource.close(); // 컴포넌트 언마운트 시 연결 종료
+    return () => eventSource.close();
 };

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -1,60 +1,84 @@
 import { useState, useEffect, useRef } from "react";
 import styles from "./Chatbot.module.css";
 import { Send } from "lucide-react";
+import ReactMarkdown from "react-markdown";
 import { getNewsDetailsAsk } from "../../api/detailsAPI.js";
 
-//번역 함수 (text반환)
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
-//전역 현재 사용자 언어
 import { useLanguage } from "../../util/LanguageContext.jsx";
+import { useAuth } from "../../util/AuthContext.jsx";
 
 export default function Chatbot({ articleId }) {
     const [input, setInput] = useState("");
     const [messages, setMessages] = useState([
         { type: "bot", text: "안녕하세요! 무엇을 도와드릴까요?" }
     ]);
+    const [isStreaming, setIsStreaming] = useState(false);
     const chatRef = useRef(null);
+    const closeEventSourceRef = useRef(null);
 
-    // 전역 현재 사용자 언어
     const { language } = useLanguage();
+    const { token } = useAuth();
 
-    // placeholder 변수
     const [placeholder, setPlaceholder] = useState("질문을 입력하세요...");
 
     useEffect(() => {
         const getTranslation = async () => {
-            const translatedText = await fetchTranslatedText("안녕하세요! 무엇을 도와드릴까요?", language)
+            const translatedText = await fetchTranslatedText("안녕하세요! 무엇을 도와드릴까요?", language);
             const translatedPlaceholder = await fetchTranslatedText("질문을 입력하세요...", language);
             setMessages([{ type: "bot", text: translatedText }]);
             setPlaceholder(translatedPlaceholder);
-        }
+        };
         getTranslation();
     }, [articleId, language]);
-    
+
+    // 언마운트 시 SSE 연결 종료
+    useEffect(() => {
+        return () => {
+            if (closeEventSourceRef.current) closeEventSourceRef.current();
+        };
+    }, []);
 
     const handleSend = () => {
-        if (!input.trim()) return;
+        if (!input.trim() || isStreaming) return;
 
-        const newMessages = [...messages, { type: "user", text: input }];
-        setMessages(newMessages);
+        const userText = input;
+        const newMessages = [...messages, { type: "user", text: userText }];
+        setMessages([...newMessages, { type: "bot", text: "" }]);
         setInput("");
+        setIsStreaming(true);
 
-        // 봇의 응답을 빈 문자열로 추가
-        const botMsg = { type: "bot", text: "" };
-        setMessages([...newMessages, botMsg]);
-
-        getNewsDetailsAsk(
+        const close = getNewsDetailsAsk(
             articleId,
-            input,
+            userText,
             (chunk) => {
                 setMessages((prev) => {
                     const updated = [...prev];
-                    updated[updated.length - 1].text += chunk; // 새 글자만 추가
+                    updated[updated.length - 1] = {
+                        ...updated[updated.length - 1],
+                        text: updated[updated.length - 1].text + chunk,
+                    };
                     return updated;
                 });
             },
-            (error) => console.error("스트리밍 에러:", error)
+            () => {
+                setIsStreaming(false);
+            },
+            (error) => {
+                console.error("스트리밍 에러:", error);
+                setIsStreaming(false);
+                setMessages((prev) => {
+                    const updated = [...prev];
+                    if (updated[updated.length - 1].text === "") {
+                        updated[updated.length - 1] = { type: "bot", text: "응답을 가져오는 데 실패했습니다." };
+                    }
+                    return updated;
+                });
+            },
+            token
         );
+
+        closeEventSourceRef.current = close;
     };
 
     useEffect(() => {
@@ -64,12 +88,27 @@ export default function Chatbot({ articleId }) {
     return (
         <div className={styles.chatbot}>
             <div className={styles.chatHeader}>Global AI</div>
+            {!token && (
+                <div className={styles.loginNotice}>
+                    💡 로그인하면 대화 내역이 저장되고 문맥이 이어집니다.
+                </div>
+            )}
             <div className={styles.chatBody} ref={chatRef}>
                 {messages.map((msg, index) => (
                     <div key={index} className={msg.type === "bot" ? styles.botMessage : styles.userMessage}>
-                        {msg.text}
+                        {msg.type === "bot"
+                            ? <div className={styles.markdown}><ReactMarkdown>{msg.text}</ReactMarkdown></div>
+                            : msg.text
+                        }
                     </div>
                 ))}
+                {isStreaming && messages[messages.length - 1]?.text === "" && (
+                    <div className={styles.botMessage}>
+                        <span className={styles.typingIndicator}>
+                            <span /><span /><span />
+                        </span>
+                    </div>
+                )}
             </div>
             <div className={styles.chatInput}>
                 <input
@@ -77,9 +116,10 @@ export default function Chatbot({ articleId }) {
                     value={input}
                     onChange={(e) => setInput(e.target.value)}
                     placeholder={placeholder}
+                    disabled={isStreaming}
                     onKeyDown={(e) => e.key === "Enter" && handleSend()}
                 />
-                <button onClick={handleSend}>
+                <button onClick={handleSend} disabled={isStreaming}>
                     <Send size={20} />
                 </button>
             </div>

--- a/FrontEnd/src/components/detailsPage/Chatbot.module.css
+++ b/FrontEnd/src/components/detailsPage/Chatbot.module.css
@@ -20,6 +20,15 @@
     border-bottom: 1px solid #ddd;
 }
 
+.loginNotice {
+    background: #fffbea;
+    border-bottom: 1px solid #f0e0a0;
+    color: #7a6000;
+    font-size: 13px;
+    padding: 7px 14px;
+    text-align: center;
+}
+
 .chatBody {
     height: 400px;
     overflow-y: auto;
@@ -77,4 +86,79 @@
 
 .chatInput button:hover {
     background: #3e3e3e;
+}
+
+/* 마크다운 렌더링 스타일 */
+.markdown {
+    line-height: 1.6;
+    word-break: break-word;
+}
+
+.markdown p {
+    margin: 0 0 8px 0;
+}
+
+.markdown p:last-child {
+    margin-bottom: 0;
+}
+
+.markdown strong {
+    font-weight: 700;
+}
+
+.markdown ul,
+.markdown ol {
+    padding-left: 20px;
+    margin: 6px 0;
+}
+
+.markdown li {
+    margin-bottom: 4px;
+}
+
+.markdown h1, .markdown h2, .markdown h3 {
+    font-weight: 700;
+    margin: 10px 0 4px;
+}
+
+.markdown code {
+    background: rgba(0, 0, 0, 0.08);
+    border-radius: 4px;
+    padding: 1px 5px;
+    font-size: 0.9em;
+}
+
+.chatInput input:disabled {
+    background: #f0f0f0;
+    cursor: not-allowed;
+}
+
+.chatInput button:disabled {
+    background: #aaa;
+    cursor: not-allowed;
+}
+
+/* 타이핑 인디케이터 (점 세 개 애니메이션) */
+.typingIndicator {
+    display: inline-flex;
+    gap: 4px;
+    align-items: center;
+    padding: 2px 0;
+}
+
+.typingIndicator span {
+    width: 7px;
+    height: 7px;
+    background-color: #888;
+    border-radius: 50%;
+    animation: typingBounce 1.2s infinite ease-in-out;
+}
+
+.typingIndicator span:nth-child(1) { animation-delay: 0s; }
+.typingIndicator span:nth-child(2) { animation-delay: 0.2s; }
+.typingIndicator span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes typingBounce {
+    0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+    30%            { transform: translateY(-5px); opacity: 1; }
 }

--- a/FrontEnd/src/components/detailsPage/Sidebar.jsx
+++ b/FrontEnd/src/components/detailsPage/Sidebar.jsx
@@ -33,10 +33,15 @@ export default function Sidebar({ recentNewsList }) {
             className={styles.articleItem}
             onClick={() => navigate(`/detail/${article.id}`)}
           >
-            <img
-              src={article.urlToImage}
-              alt="썸네일"
+            <div
               className={styles.thumbnail}
+              style={{
+                backgroundImage: article.urlToImage
+                  ? `url(${article.urlToImage})`
+                  : undefined,
+                backgroundSize: "cover",
+                backgroundPosition: "center",
+              }}
             />
             <div>
               <p className={styles.articleSource}>

--- a/FrontEnd/src/components/detailsPage/Sidebar.module.css
+++ b/FrontEnd/src/components/detailsPage/Sidebar.module.css
@@ -56,8 +56,12 @@
 .thumbnail {
   width: 70px;
   height: 70px;
+  min-width: 70px;
   margin-right: 20px;
   border-radius: 12px;
+  background-image: linear-gradient(135deg, #c8c8c8 0%, #a0a0a0 50%, #b8b8b8 100%);
+  background-size: cover;
+  background-position: center;
 }
 
 .articleSource {

--- a/FrontEnd/vite.config.js
+++ b/FrontEnd/vite.config.js
@@ -11,6 +11,12 @@ export default defineConfig({
       '/api': {
         target: 'http://localhost:8080',
         changeOrigin: true,
+        configure: (proxy) => {
+          // SSE 스트리밍 요청 시 프록시 버퍼링 비활성화
+          proxy.on('proxyReq', (proxyReq) => {
+            proxyReq.setHeader('Accept-Encoding', 'identity');
+          });
+        },
       },
       '/oauth2': {
         target: 'http://localhost:8080',


### PR DESCRIPTION
## 📌 작업 내용

### feat: 챗봇 SSE 스트리밍 연동 및 마크다운 렌더링
- Vite 프록시 SSE 버퍼링 해제 (Accept-Encoding: identity) → 순차 출력 정상화
- react-markdown 적용으로 **굵게**, 리스트, 제목 등 마크다운 렌더링
- 타이핑 인디케이터(점 세 개 바운스) 추가
- 스트리밍 중 입력창/버튼 비활성화 처리

### fix: SSE 인수 오류 수정 및 비로그인 안내
- getNewsDetailsAsk onComplete/onError 인수 순서 버그 수정 (크래시 방지)
- 로그인 시 JWT를 쿼리 파라미터로 전달 → BE 히스토리 저장 연동
- 비로그인 시 챗봇 상단에 로그인 유도 안내 배너 표시

### BE (develop 직접 반영)
- JwtAuthenticationFilter: SSE용 쿼리 파라미터 토큰 추출 추가
- AiSseService: 비로그인 프롬프트 개선 (일상 대화 간결 응답)

## ✅ 체크리스트
- [x] 로컬 확인 완료
- [x] BE 연동 확인 완료

## 🔗 관련 이슈
Closes #67 