### PR TITLE
Feat/#69 채팅 히스토리 연동 및 전체적인 UI/UX 개선 

### DIFF
--- a/FrontEnd/index.html
+++ b/FrontEnd/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/png" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Global Times</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/FrontEnd/src/api/chatAPI.js
+++ b/FrontEnd/src/api/chatAPI.js
@@ -1,0 +1,23 @@
+import { authAPI } from "./authAPI";
+
+// 기사별 전체 대화 내역 (상세 페이지 챗봇)
+export const getChatsByArticle = async (articleId) => {
+    try {
+        const response = await authAPI.get(`/api/articles/${articleId}/chat-history`);
+        return response.data?.data ?? [];
+    } catch (error) {
+        console.error("채팅 히스토리 조회 실패:", error);
+        return [];
+    }
+};
+
+// 기사별 마지막 대화 미리보기 목록 (플로팅 팝업)
+export const getChatList = async () => {
+    try {
+        const response = await authAPI.get("/api/user/chat-history");
+        return response.data?.data ?? [];
+    } catch (error) {
+        console.error("채팅 히스토리 목록 조회 실패:", error);
+        return [];
+    }
+};

--- a/FrontEnd/src/components/chat/ChatHistoryButton.jsx
+++ b/FrontEnd/src/components/chat/ChatHistoryButton.jsx
@@ -1,0 +1,116 @@
+import { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import { MessageSquare, X } from "lucide-react";
+import { useAuth } from "../../util/AuthContext.jsx";
+import { getChatList } from "../../api/chatAPI.js";
+import styles from "./ChatHistoryButton.module.css";
+
+export default function ChatHistoryButton() {
+    const { token } = useAuth();
+    const navigate = useNavigate();
+    const [isOpen, setIsOpen] = useState(false);
+    const [chatList, setChatList] = useState([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const popupRef = useRef(null);
+
+    // 로그인 상태에서 팝업 열 때 히스토리 불러오기
+    useEffect(() => {
+        if (!isOpen || !token) return;
+        const fetchList = async () => {
+            setIsLoading(true);
+            const data = await getChatList();
+            setChatList(data);
+            setIsLoading(false);
+        };
+        fetchList();
+    }, [isOpen, token]);
+
+    // 팝업 외부 클릭 시 닫기
+    useEffect(() => {
+        const handleClickOutside = (e) => {
+            if (popupRef.current && !popupRef.current.contains(e.target)) {
+                setIsOpen(false);
+            }
+        };
+        if (isOpen) document.addEventListener("mousedown", handleClickOutside);
+        return () => document.removeEventListener("mousedown", handleClickOutside);
+    }, [isOpen]);
+
+    return (
+        <div className={styles.wrapper} ref={popupRef}>
+            {/* 팝업 */}
+            {isOpen && (
+                <div className={styles.popup}>
+                    <div className={styles.popupHeader}>
+                        <span>채팅 히스토리</span>
+                        <button onClick={() => setIsOpen(false)} className={styles.closeBtn}>
+                            <X size={16} />
+                        </button>
+                    </div>
+                    <div className={styles.popupBody}>
+                        {/* 비로그인 안내 */}
+                        {!token && (
+                            <div className={styles.loginPrompt}>
+                                <MessageSquare size={36} className={styles.promptIcon} />
+                                <p className={styles.promptText}>
+                                    로그인하면 기사별 AI 대화 내역을<br />언제든지 다시 볼 수 있어요.
+                                </p>
+                                <button
+                                    className={styles.loginBtn}
+                                    onClick={() => {
+                                        setIsOpen(false);
+                                        window.location.href = "/oauth2/authorization/google";
+                                    }}
+                                >
+                                    Google로 로그인
+                                </button>
+                            </div>
+                        )}
+
+                        {/* 로그인 상태 */}
+                        {token && isLoading && <p className={styles.empty}>불러오는 중...</p>}
+                        {token && !isLoading && chatList.length === 0 && (
+                            <p className={styles.empty}>저장된 대화 내역이 없습니다.</p>
+                        )}
+                        {token && !isLoading && chatList.map((item) => (
+                            <div
+                                key={item.articleId}
+                                className={styles.chatItem}
+                                onClick={() => {
+                                    setIsOpen(false);
+                                    navigate(`/detail/${item.articleId}`);
+                                }}
+                            >
+                                <div
+                                    className={styles.thumbnail}
+                                    style={{
+                                        backgroundImage: item.thumbnailUrl
+                                            ? `url(${item.thumbnailUrl})`
+                                            : undefined,
+                                    }}
+                                />
+                                <div className={styles.chatInfo}>
+                                    <p className={styles.articleTitle}>{item.articleTitle}</p>
+                                    <p className={styles.lastQuestion}>Q: {item.lastQuestion}</p>
+                                    <p className={styles.preview}>{item.lastAnswerPreview}</p>
+                                    <p className={styles.time}>
+                                        {new Date(item.lastChatAt).toLocaleString("ko-KR")}
+                                    </p>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {/* 플로팅 버튼 */}
+            <button
+                className={styles.fab}
+                onClick={() => setIsOpen((prev) => !prev)}
+                title="채팅 히스토리"
+            >
+                <MessageSquare size={22} />
+            </button>
+        </div>
+    );
+}

--- a/FrontEnd/src/components/chat/ChatHistoryButton.jsx
+++ b/FrontEnd/src/components/chat/ChatHistoryButton.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { MessageSquare, X } from "lucide-react";
+import ReactMarkdown from "react-markdown";
 import { useAuth } from "../../util/AuthContext.jsx";
 import { getChatList } from "../../api/chatAPI.js";
 import styles from "./ChatHistoryButton.module.css";
@@ -92,7 +93,9 @@ export default function ChatHistoryButton() {
                                 <div className={styles.chatInfo}>
                                     <p className={styles.articleTitle}>{item.articleTitle}</p>
                                     <p className={styles.lastQuestion}>Q: {item.lastQuestion}</p>
-                                    <p className={styles.preview}>{item.lastAnswerPreview}</p>
+                                    <div className={styles.preview}>
+                                        <ReactMarkdown>{item.lastAnswerPreview}</ReactMarkdown>
+                                    </div>
                                     <p className={styles.time}>
                                         {new Date(item.lastChatAt).toLocaleString("ko-KR")}
                                     </p>

--- a/FrontEnd/src/components/chat/ChatHistoryButton.module.css
+++ b/FrontEnd/src/components/chat/ChatHistoryButton.module.css
@@ -1,0 +1,200 @@
+.wrapper {
+    position: fixed;
+    bottom: 32px;
+    right: 32px;
+    z-index: 200;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
+}
+
+/* 플로팅 버튼 */
+.fab {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: #1a1a1a;
+    color: white;
+    border: none;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.fab:hover {
+    background: #f0c040;
+    color: #1a1a1a;
+    transform: scale(1.07);
+}
+
+/* 팝업 */
+.popup {
+    width: 340px;
+    max-height: 480px;
+    background: #fff;
+    border-radius: 14px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    animation: fadeUp 0.2s ease;
+}
+
+@keyframes fadeUp {
+    from { opacity: 0; transform: translateY(12px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.popupHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 16px;
+    font-weight: 700;
+    font-size: 15px;
+    border-bottom: 1px solid #eee;
+    background: #fafafa;
+}
+
+.closeBtn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #888;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+}
+
+.popupBody {
+    overflow-y: auto;
+    flex: 1;
+}
+
+.empty {
+    text-align: center;
+    color: #aaa;
+    font-size: 14px;
+    padding: 32px 16px;
+    margin: 0;
+}
+
+/* 비로그인 안내 */
+.loginPrompt {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    padding: 36px 24px;
+    text-align: center;
+}
+
+.promptIcon {
+    color: #ccc;
+}
+
+.promptText {
+    font-size: 14px;
+    color: #555;
+    line-height: 1.6;
+    margin: 0;
+}
+
+.loginBtn {
+    background: #1a1a1a;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    padding: 10px 20px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.loginBtn:hover {
+    background: #f0c040;
+    color: #1a1a1a;
+    transform: translateY(-1px);
+}
+
+.chatItem {
+    display: flex;
+    gap: 12px;
+    padding: 12px 16px;
+    cursor: pointer;
+    border-bottom: 1px solid #f0f0f0;
+    transition: background 0.15s ease;
+}
+
+.chatItem:hover {
+    background: #f8f6ee;
+}
+
+.thumbnail {
+    width: 52px;
+    height: 52px;
+    min-width: 52px;
+    border-radius: 8px;
+    background-color: #ccc;
+    background-image: linear-gradient(135deg, #c8c8c8 0%, #a0a0a0 50%, #b8b8b8 100%);
+    background-size: cover;
+    background-position: center;
+}
+
+.chatInfo {
+    flex: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.articleTitle {
+    font-size: 13px;
+    font-weight: 700;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin: 0;
+    color: #222;
+}
+
+.lastQuestion {
+    font-size: 12px;
+    color: #555;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    margin: 0;
+}
+
+.preview {
+    font-size: 12px;
+    color: #888;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    margin: 0;
+}
+
+.time {
+    font-size: 11px;
+    color: #bbb;
+    margin: 0;
+}
+
+@media (max-width: 480px) {
+    .wrapper {
+        bottom: 20px;
+        right: 16px;
+    }
+    .popup {
+        width: calc(100vw - 32px);
+    }
+}

--- a/FrontEnd/src/components/commons/header/Header.jsx
+++ b/FrontEnd/src/components/commons/header/Header.jsx
@@ -66,7 +66,7 @@ export default function Header() {
             {isLoggedIn ? (
               <>
                 <span className={styles.nickname}>
-                  {user?.nickname ?? ""} 🌐
+                  {user?.nickname ?? ""} 💡
                 </span>
                 <button onClick={logout} className={`${styles.authButton} ${styles.logoutButton}`}>
                   <TranslatedText text="로그아웃" />
@@ -197,7 +197,7 @@ export default function Header() {
           {isLoggedIn ? (
             <>
               <span className={styles.mobileNickname}>
-                {user?.nickname ?? ""} 🌐
+                {user?.nickname ?? ""} 💡
               </span>
               <button onClick={() => { logout(); setMenuOpen(false); }} className={`${styles.authButton} ${styles.logoutButton}`}>
                 <TranslatedText text="로그아웃" />

--- a/FrontEnd/src/components/commons/header/Header.jsx
+++ b/FrontEnd/src/components/commons/header/Header.jsx
@@ -65,13 +65,15 @@ export default function Header() {
           <div className={styles.authContainer}>
             {isLoggedIn ? (
               <>
-                <span className={styles.nickname}>{user?.nickname ?? ""}</span>
-                <button onClick={logout} className={styles.authButton}>
+                <span className={styles.nickname}>
+                  {user?.nickname ?? ""} 🌐
+                </span>
+                <button onClick={logout} className={`${styles.authButton} ${styles.logoutButton}`}>
                   <TranslatedText text="로그아웃" />
                 </button>
               </>
             ) : (
-              <button onClick={handleLogin} className={styles.authButton}>
+              <button onClick={handleLogin} className={`${styles.authButton} ${styles.loginButton}`}>
                 <TranslatedText text="로그인" />
               </button>
             )}
@@ -194,13 +196,15 @@ export default function Header() {
         <div className={styles.mobileMenuAuth}>
           {isLoggedIn ? (
             <>
-              <span className={styles.mobileNickname}>{user?.nickname ?? ""}</span>
-              <button onClick={() => { logout(); setMenuOpen(false); }} className={styles.authButton}>
+              <span className={styles.mobileNickname}>
+                {user?.nickname ?? ""} 🌐
+              </span>
+              <button onClick={() => { logout(); setMenuOpen(false); }} className={`${styles.authButton} ${styles.logoutButton}`}>
                 <TranslatedText text="로그아웃" />
               </button>
             </>
           ) : (
-            <button onClick={handleLogin} className={styles.authButton}>
+            <button onClick={handleLogin} className={`${styles.authButton} ${styles.loginButton}`}>
               <TranslatedText text="로그인" />
             </button>
           )}

--- a/FrontEnd/src/components/commons/header/Header.jsx
+++ b/FrontEnd/src/components/commons/header/Header.jsx
@@ -5,6 +5,7 @@ import Logo from "../../../assets/logo/logo.png";
 import { useLanguage } from "../../../util/LanguageContext.jsx";
 import { useAuth } from "../../../util/AuthContext.jsx";
 import TranslatedText from "../../../api/TranslatedText.jsx";
+import LanguageSelect from "./LanguageSelect.jsx";
 
 export default function Header() {
   const navigate = useNavigate();
@@ -78,90 +79,11 @@ export default function Header() {
               </button>
             )}
           </div>
-          <div className={`${styles.languageToggle} ${isHome ? styles.whiteText : styles.blackText}`}>
-            <select value={language} onChange={(e) => setLanguage(e.target.value)}>
-            <option value="ko">한국어</option>
-            <option value="en">English</option>
-            <option value="ja">
-              日本語 (<TranslatedText text="일본어" />)
-            </option>
-            <option value="zh-CN">
-              中文 (<TranslatedText text="간체 중국어" />)
-            </option>
-            <option value="zh-TW">
-              繁體中文 (<TranslatedText text="번체 중국어" />)
-            </option>
-            <option value="vi">
-              Tiếng Việt (<TranslatedText text="베트남어" />)
-            </option>
-            <option value="th">
-              ไทย (<TranslatedText text="태국어" />)
-            </option>
-            <option value="id">
-              Bahasa Indonesia (<TranslatedText text="인도네시아어" />)
-            </option>
-            <option value="ms">
-              Bahasa Melayu (<TranslatedText text="말레이어" />)
-            </option>
-            <option value="hi">
-              हिन्दी (<TranslatedText text="힌디어" />)
-            </option>
-            <option value="bn">
-              বাংলা (<TranslatedText text="벵골어" />)
-            </option>
-            <option value="ta">
-              தமிழ் (<TranslatedText text="타밀어" />)
-            </option>
-            <option value="te">
-              తెలుగు (<TranslatedText text="텔루구어" />)
-            </option>
-            <option value="ur">
-              اردو (<TranslatedText text="우르두어" />)
-            </option>
-            <option value="km">
-              ភាសាខ្មែរ (<TranslatedText text="크메르어" />)
-            </option>
-            <option value="my">
-              မြန်မာဘာသာ (<TranslatedText text="버마어/미얀마어" />)
-            </option>
-            <option value="ne">
-              नेपाली (<TranslatedText text="네팔어" />)
-            </option>
-            <option value="si">
-              සිංහල (<TranslatedText text="싱할라어" />)
-            </option>
-            <option value="lo">
-              ລາວ (<TranslatedText text="라오어" />)
-            </option>
-            <option value="ru">
-              Русский (<TranslatedText text="러시아어" />)
-            </option>
-            <option value="pa">
-              ਪੰਜਾਬੀ (<TranslatedText text="펀자브어" />)
-            </option>
-            <option value="gu">
-              ગુજરાતી (<TranslatedText text="구자라트어" />)
-            </option>
-            <option value="ml">
-              മലയാളം (<TranslatedText text="말라얄람어" />)
-            </option>
-            <option value="kn">
-              ಕನ್ನಡ (<TranslatedText text="칸나다어" />)
-            </option>
-            <option value="mr">
-              मराठी (<TranslatedText text="마라티어" />)
-            </option>
-            <option value="fr">
-              Français (<TranslatedText text="프랑스어" />)
-            </option>
-            <option value="es">
-              Español (<TranslatedText text="스페인어" />)
-            </option>
-            <option value="de">
-              Deutsch (<TranslatedText text="독일어" />)
-            </option>
-          </select>
-          </div>
+          <LanguageSelect
+            value={language}
+            onChange={setLanguage}
+            isHome={isHome}
+          />
         </div>
 
         {/* 햄버거 버튼 (모바일) */}
@@ -210,17 +132,12 @@ export default function Header() {
           )}
         </div>
         <div className={styles.mobileMenuLang}>
-          <select value={language} onChange={(e) => setLanguage(e.target.value)}>
-            <option value="ko">한국어</option>
-            <option value="en">English</option>
-            <option value="ja">日本語</option>
-            <option value="zh-CN">中文 (간체)</option>
-            <option value="zh-TW">繁體中文 (번체)</option>
-            <option value="fr">Français</option>
-            <option value="es">Español</option>
-            <option value="de">Deutsch</option>
-            <option value="ru">Русский</option>
-          </select>
+          <LanguageSelect
+            value={language}
+            onChange={setLanguage}
+            isHome={true}
+            isMobile={true}
+          />
         </div>
       </div>
     </div>

--- a/FrontEnd/src/components/commons/header/Header.module.css
+++ b/FrontEnd/src/components/commons/header/Header.module.css
@@ -101,10 +101,6 @@
   border-color: #f0c040;
 }
 
-.languageToggle select option {
-  background: #1a1a1a;
-  color: white;
-}
 
 .languageToggle::after {
   content: "▾";

--- a/FrontEnd/src/components/commons/header/Header.module.css
+++ b/FrontEnd/src/components/commons/header/Header.module.css
@@ -73,47 +73,49 @@
 
 .languageToggle {
   position: relative;
-  border-radius: 20px;
 }
 
 .languageToggle select {
-  width: 150px;
+  width: 130px;
   appearance: none;
   background: transparent;
-  border: 1px solid currentColor;
-  padding: 5px 30px 5px 10px;
-  font-size: 16px;
-  font-weight: bold;
+  border: 1.5px solid rgba(200, 200, 200, 0.5);
+  padding: 5px 28px 5px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
   cursor: pointer;
-  border-radius: 10px;
+  border-radius: 20px;
   outline: none;
   box-shadow: none;
+  color: currentColor;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  letter-spacing: 0.01em;
+}
+
+.languageToggle select:hover {
+  border-color: #f0c040;
+}
+
+.languageToggle select:focus {
+  border-color: #f0c040;
 }
 
 .languageToggle select option {
-  background: white;
-  color: black;
-  border-radius: 0;
-}
-
-.blackText .languageToggle select option {
-  background: black;
+  background: #1a1a1a;
   color: white;
-  border-radius: 0;
 }
 
 .languageToggle::after {
-  content: "▼";
+  content: "▾";
   position: absolute;
-  right: 10px;
+  right: 11px;
   top: 50%;
   transform: translateY(-50%);
   pointer-events: none;
+  font-size: 13px;
   color: currentColor;
-}
-
-.blackText .languageToggle::after {
-  color: black;
+  opacity: 0.7;
 }
 
 .active {

--- a/FrontEnd/src/components/commons/header/Header.module.css
+++ b/FrontEnd/src/components/commons/header/Header.module.css
@@ -143,6 +143,9 @@
 .nickname {
   font-size: 15px;
   font-weight: bold;
+  color: #f0c040;
+  text-shadow: 0 0 8px rgba(240, 192, 64, 0.35);
+  letter-spacing: 0.01em;
 }
 
 .authButton {
@@ -159,6 +162,31 @@
 
 .authButton:hover {
   opacity: 0.7;
+}
+
+/* 로그인 버튼 - 골드 테두리 강조 */
+.loginButton {
+  border-color: #f0c040 !important;
+  color: #f0c040 !important;
+}
+
+.loginButton:hover {
+  background: rgba(240, 192, 64, 0.12) !important;
+  opacity: 1 !important;
+}
+
+/* 로그아웃 버튼 - 은은한 회색 */
+.logoutButton {
+  border-color: rgba(180, 180, 180, 0.6) !important;
+  color: inherit;
+  font-size: 13px !important;
+  padding: 4px 10px !important;
+}
+
+.logoutButton:hover {
+  border-color: #f0c040 !important;
+  color: #f0c040 !important;
+  opacity: 1 !important;
 }
 
 /* 데스크탑 네비게이션 - 정중앙 */

--- a/FrontEnd/src/components/commons/header/LanguageSelect.jsx
+++ b/FrontEnd/src/components/commons/header/LanguageSelect.jsx
@@ -1,0 +1,83 @@
+import { useState, useRef, useEffect } from "react";
+import styles from "./LanguageSelect.module.css";
+
+const LANGUAGES = [
+  { value: "ko", label: "한국어" },
+  { value: "en", label: "English" },
+  { value: "ja", label: "日本語" },
+  { value: "zh-CN", label: "中文 (简体)" },
+  { value: "zh-TW", label: "繁體中文" },
+  { value: "vi", label: "Tiếng Việt" },
+  { value: "th", label: "ไทย" },
+  { value: "id", label: "Bahasa Indonesia" },
+  { value: "ms", label: "Bahasa Melayu" },
+  { value: "hi", label: "हिन्दी" },
+  { value: "bn", label: "বাংলা" },
+  { value: "ta", label: "தமிழ்" },
+  { value: "te", label: "తెలుగు" },
+  { value: "ur", label: "اردو" },
+  { value: "km", label: "ភាសាខ្មែរ" },
+  { value: "my", label: "မြန်မာဘာသာ" },
+  { value: "ne", label: "नेपाली" },
+  { value: "si", label: "සිංහල" },
+  { value: "lo", label: "ລາວ" },
+  { value: "ru", label: "Русский" },
+  { value: "pa", label: "ਪੰਜਾਬੀ" },
+  { value: "gu", label: "ગુજરાતી" },
+  { value: "ml", label: "മലയാളം" },
+  { value: "kn", label: "ಕನ್ನಡ" },
+  { value: "mr", label: "मराठी" },
+  { value: "fr", label: "Français" },
+  { value: "es", label: "Español" },
+  { value: "de", label: "Deutsch" },
+];
+
+export default function LanguageSelect({ value, onChange, isHome, isMobile = false }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const selected = LANGUAGES.find((l) => l.value === value);
+
+  const themeClass = isHome ? styles.dark : styles.light;
+  const mobileClass = isMobile ? styles.mobile : "";
+
+  return (
+    <div ref={ref} className={`${styles.container} ${themeClass} ${mobileClass}`}>
+      <button
+        className={styles.trigger}
+        onClick={() => setIsOpen((prev) => !prev)}
+        type="button"
+      >
+        <span>{selected?.label}</span>
+        <span className={`${styles.arrow} ${isOpen ? styles.arrowOpen : ""}`}>▾</span>
+      </button>
+
+      {isOpen && (
+        <ul className={styles.dropdown}>
+          {LANGUAGES.map((lang) => (
+            <li
+              key={lang.value}
+              className={`${styles.option} ${lang.value === value ? styles.selected : ""}`}
+              onClick={() => {
+                onChange(lang.value);
+                setIsOpen(false);
+              }}
+            >
+              {lang.label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/FrontEnd/src/components/commons/header/LanguageSelect.module.css
+++ b/FrontEnd/src/components/commons/header/LanguageSelect.module.css
@@ -1,0 +1,170 @@
+.container {
+  position: relative;
+  display: inline-block;
+}
+
+/* 트리거 버튼 (pill 모양) */
+.trigger {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 130px;
+  padding: 5px 12px;
+  font-size: 13px;
+  font-weight: 600;
+  font-family: inherit;
+  border-radius: 20px;
+  border: 1.5px solid rgba(200, 200, 200, 0.5);
+  background: transparent;
+  cursor: pointer;
+  outline: none;
+  letter-spacing: 0.01em;
+  transition: border-color 0.2s ease;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trigger:hover {
+  border-color: #f0c040;
+}
+
+.arrow {
+  font-size: 12px;
+  opacity: 0.7;
+  transition: transform 0.25s ease;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.arrowOpen {
+  transform: rotate(180deg);
+}
+
+/* 드롭다운 리스트 */
+.dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  list-style: none;
+  margin: 0;
+  padding: 6px 0;
+  border-radius: 14px;
+  min-width: 160px;
+  max-height: 280px;
+  overflow-y: auto;
+  z-index: 200;
+  animation: dropdownFadeIn 0.18s ease;
+
+  /* 커스텀 스크롤바 */
+  scrollbar-width: thin;
+}
+
+.dropdown::-webkit-scrollbar {
+  width: 4px;
+}
+
+.dropdown::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+@keyframes dropdownFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.option {
+  padding: 9px 16px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+  white-space: nowrap;
+}
+
+/* ───── 다크 테마 (랜딩/인트로 페이지) ───── */
+.dark .trigger {
+  color: white;
+  border-color: rgba(200, 200, 200, 0.5);
+}
+
+.dark .dropdown {
+  background: rgba(22, 22, 22, 0.97);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.dark .dropdown::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 4px;
+}
+
+.dark .option {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dark .option:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: white;
+}
+
+.dark .selected {
+  color: #f0c040;
+  font-weight: 700;
+  background: rgba(240, 192, 64, 0.12);
+}
+
+/* ───── 라이트 테마 (그 외 페이지) ───── */
+.light .trigger {
+  color: #333;
+  border-color: rgba(100, 100, 100, 0.3);
+}
+
+.light .trigger:hover {
+  border-color: #f0c040;
+}
+
+.light .dropdown {
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+}
+
+.light .dropdown::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+}
+
+.light .option {
+  color: #333;
+}
+
+.light .option:hover {
+  background: rgba(240, 192, 64, 0.1);
+  color: #b8860b;
+}
+
+.light .selected {
+  color: #b8860b;
+  font-weight: 700;
+  background: rgba(240, 192, 64, 0.12);
+}
+
+/* ───── 모바일 전용 ───── */
+.mobile .trigger {
+  width: 100%;
+  border-radius: 10px;
+}
+
+.mobile .dropdown {
+  left: 0;
+  right: 0;
+  min-width: unset;
+  border-radius: 10px;
+}

--- a/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
+++ b/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
@@ -2,8 +2,8 @@ import styles from "./ArticleDetail.module.css";
 import { FaBookmark } from "react-icons/fa";
 import { useState, useEffect } from "react";
 import { MutatingDots } from "react-loader-spinner";
+import ReactMarkdown from "react-markdown";
 
-//컴포넌트 변경
 import TranslatedText from "../../api/TranslatedText.jsx";
 
 export default function ArticleDetail({ id, newsDetail, content, isLoading, isSummaryLoading }) {
@@ -70,7 +70,9 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading, isSu
            visible={true}
          />
          ) : content ? (
-           <p className={styles.content}><TranslatedText text={content}/></p>
+           <div className={styles.content}>
+             <ReactMarkdown>{content}</ReactMarkdown>
+           </div>
          ) : (
            <p className={styles.content}>요약 정보를 불러올 수 없습니다.</p>
          )

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -3,6 +3,7 @@ import styles from "./Chatbot.module.css";
 import { Send } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { getNewsDetailsAsk } from "../../api/detailsAPI.js";
+import { getChatsByArticle } from "../../api/chatAPI.js";
 
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
@@ -10,10 +11,9 @@ import { useAuth } from "../../util/AuthContext.jsx";
 
 export default function Chatbot({ articleId }) {
     const [input, setInput] = useState("");
-    const [messages, setMessages] = useState([
-        { type: "bot", text: "안녕하세요! 무엇을 도와드릴까요?" }
-    ]);
+    const [messages, setMessages] = useState([]);
     const [isStreaming, setIsStreaming] = useState(false);
+    const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
     const chatRef = useRef(null);
     const closeEventSourceRef = useRef(null);
 
@@ -22,15 +22,38 @@ export default function Chatbot({ articleId }) {
 
     const [placeholder, setPlaceholder] = useState("질문을 입력하세요...");
 
+    // 인사말 번역 + 로그인 시 이전 대화 내역 불러오기
     useEffect(() => {
-        const getTranslation = async () => {
-            const translatedText = await fetchTranslatedText("안녕하세요! 무엇을 도와드릴까요?", language);
+        const init = async () => {
+            const translatedGreeting = await fetchTranslatedText("안녕하세요! 무엇을 도와드릴까요?", language);
             const translatedPlaceholder = await fetchTranslatedText("질문을 입력하세요...", language);
-            setMessages([{ type: "bot", text: translatedText }]);
             setPlaceholder(translatedPlaceholder);
+
+            if (token && articleId) {
+                const history = await getChatsByArticle(articleId);
+                if (history.length > 0) {
+                    // 이전 대화 내역을 messages로 변환
+                    const historyMessages = [];
+                    history.forEach((chat) => {
+                        historyMessages.push({ type: "user", text: chat.question });
+                        historyMessages.push({ type: "bot", text: chat.answer });
+                    });
+                    setMessages([
+                        { type: "bot", text: translatedGreeting },
+                        { type: "divider", text: "── 이전 대화 내역 ──" },
+                        ...historyMessages,
+                        { type: "divider", text: "── 새 대화 ──" },
+                    ]);
+                } else {
+                    setMessages([{ type: "bot", text: translatedGreeting }]);
+                }
+            } else {
+                setMessages([{ type: "bot", text: translatedGreeting }]);
+            }
+            setIsHistoryLoaded(true);
         };
-        getTranslation();
-    }, [articleId, language]);
+        init();
+    }, [articleId, language, token]);
 
     // 언마운트 시 SSE 연결 종료
     useEffect(() => {
@@ -94,14 +117,19 @@ export default function Chatbot({ articleId }) {
                 </div>
             )}
             <div className={styles.chatBody} ref={chatRef}>
-                {messages.map((msg, index) => (
-                    <div key={index} className={msg.type === "bot" ? styles.botMessage : styles.userMessage}>
-                        {msg.type === "bot"
-                            ? <div className={styles.markdown}><ReactMarkdown>{msg.text}</ReactMarkdown></div>
-                            : msg.text
-                        }
-                    </div>
-                ))}
+                {messages.map((msg, index) => {
+                    if (msg.type === "divider") {
+                        return <div key={index} className={styles.divider}>{msg.text}</div>;
+                    }
+                    return (
+                        <div key={index} className={msg.type === "bot" ? styles.botMessage : styles.userMessage}>
+                            {msg.type === "bot"
+                                ? <div className={styles.markdown}><ReactMarkdown>{msg.text}</ReactMarkdown></div>
+                                : msg.text
+                            }
+                        </div>
+                    );
+                })}
                 {isStreaming && messages[messages.length - 1]?.text === "" && (
                     <div className={styles.botMessage}>
                         <span className={styles.typingIndicator}>

--- a/FrontEnd/src/components/detailsPage/Chatbot.module.css
+++ b/FrontEnd/src/components/detailsPage/Chatbot.module.css
@@ -20,6 +20,14 @@
     border-bottom: 1px solid #ddd;
 }
 
+.divider {
+    text-align: center;
+    font-size: 12px;
+    color: #aaa;
+    margin: 8px 0;
+    user-select: none;
+}
+
 .loginNotice {
     background: #fffbea;
     border-bottom: 1px solid #f0e0a0;

--- a/FrontEnd/src/components/mainPage/SearchContainer.jsx
+++ b/FrontEnd/src/components/mainPage/SearchContainer.jsx
@@ -1,85 +1,111 @@
-import styled from './SearchContainer.module.css'
-import PropTypes from 'prop-types';
+import styled from "./SearchContainer.module.css";
+import PropTypes from "prop-types";
 import { Search } from "lucide-react";
-import { useState, useEffect } from 'react';
+import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 
-export default function SearchContainer({searchTerm} ) { 
-    const navigate = useNavigate();
-    const { language } = useLanguage();
-    const [ inputSearchTerm, setInputSearchTerm ] = useState(searchTerm);
-    const [value, setValue] = useState(searchTerm || '');
-    const [placeholder, setPlaceholder] = useState("Search news");
-    const [searchLabel, setSearchLabel] = useState("Search");
+export default function SearchContainer({ searchTerm }) {
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+  const [inputSearchTerm, setInputSearchTerm] = useState(searchTerm);
+  const [value, setValue] = useState(searchTerm || "");
+  const [placeholder, setPlaceholder] = useState("검색어를 입력해주세요 ");
+  const [searchLabel, setSearchLabel] = useState("Search");
+  const [isFocused, setIsFocused] = useState(false);
 
-    useEffect(() => {
-        setInputSearchTerm(searchTerm);
-        setValue(searchTerm);
-    }, [searchTerm]);
+  useEffect(() => {
+    setInputSearchTerm(searchTerm);
+    setValue(searchTerm);
+  }, [searchTerm]);
 
-    useEffect(() => {
-        const translate = async () => {
-            const [p, s] = await Promise.all([
-                fetchTranslatedText("뉴스 검색", language),
-                fetchTranslatedText("검색", language),
-            ]);
-            setPlaceholder(p);
-            setSearchLabel(s);
-        };
-        translate();
-    }, [language]);
-    
-    function handleSearch() {
-        const keyword = inputSearchTerm.trim();
-        if (!keyword) return;
-        navigate(`/search/${keyword}`);
+  useEffect(() => {
+    const translate = async () => {
+      const [p, s] = await Promise.all([
+        fetchTranslatedText("검색어를 입력해주세요 ", language),
+        fetchTranslatedText("검색", language),
+      ]);
+      setPlaceholder(p);
+      setSearchLabel(s);
+    };
+    translate();
+  }, [language]);
+
+  function handleSearch() {
+    const keyword = inputSearchTerm.trim();
+    if (!keyword) return;
+    navigate(`/search/${keyword}`);
+  }
+
+  function handleInputChange(event) {
+    setInputSearchTerm(event.target.value);
+    setValue(event.target.value);
+  }
+
+  function handleKeyDown(event) {
+    if (event.key === "Enter") {
+      handleSearch();
     }
+  }
 
-    function handleInputChange(event){
-        setInputSearchTerm(event.target.value);
-        setValue(event.target.value);
-    }
+  function handleClickSearch() {
+    handleSearch();
+  }
 
-    function handleKeyDown(event) {
-        if (event.key === "Enter") {
-            handleSearch();
-        }
-    }
-
-    function handleClickSearch(){
-        handleSearch();
-    }
-
-
-    return(
-        <div className={styled['searchContainer--container']}>
-            <div className={styled['searchContainer--searchBar']}>
-                <div className={styled['searchContainer--searchInputContainer']}>
-                    <Search className={styled['input-icon']} size={20} />
-                    <input 
-                        className={styled['searchContainer--Input']}
-                        value={value}
-                        placeholder={placeholder}
-                        onChange={handleInputChange}
-                        onKeyDown={handleKeyDown}
-                    ></input>
-                </div>
-                <button 
-                    id="searchButton"
-                    className={styled['searchContainer--searchButton']}
-                    onClick={handleClickSearch}
-                    disabled={!value.trim()}
-                >{searchLabel}</button>
-            </div>
-            
+  return (
+    <div className={styled["searchContainer--container"]}>
+      <div className={styled["searchContainer--searchBar"]}>
+        <div className={styled["searchContainer--searchInputContainer"]}>
+          <Search className={styled["input-icon"]} size={20} />
+          <div className={styled["input-wrapper"]}>
+            <input
+              className={styled["searchContainer--Input"]}
+              value={value}
+              placeholder=""
+              onChange={handleInputChange}
+              onKeyDown={handleKeyDown}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
+            />
+            {!value && !isFocused && (
+              <div className={styled["animated-placeholder"]}>
+                <span className={styled["placeholder-text"]}>
+                  {placeholder}
+                </span>
+                <span className={styled["emoji-sad"]}>😢</span>
+                <span className={styled["emoji-happy"]}>🥰</span>
+              </div>
+            )}
+          </div>
         </div>
-    )
+        <button
+          id="searchButton"
+          className={styled["searchContainer--searchButton"]}
+          onClick={handleClickSearch}
+          disabled={!value.trim()}
+        >
+          <span>{searchLabel}</span>
+          <span className={styled["btn-dots"]}>
+            <span
+              className={styled["btn-dot"]}
+              style={{ animationDelay: "0ms" }}
+            />
+            <span
+              className={styled["btn-dot"]}
+              style={{ animationDelay: "200ms" }}
+            />
+            <span
+              className={styled["btn-dot"]}
+              style={{ animationDelay: "400ms" }}
+            />
+          </span>
+        </button>
+      </div>
+    </div>
+  );
 }
 
 SearchContainer.propTypes = {
-    searchTerm: PropTypes.string.isRequired,   // searchTerm은 string이어야 함
+  searchTerm: PropTypes.string.isRequired, // searchTerm은 string이어야 함
 };
-
-

--- a/FrontEnd/src/components/mainPage/SearchContainer.jsx
+++ b/FrontEnd/src/components/mainPage/SearchContainer.jsx
@@ -3,16 +3,33 @@ import PropTypes from 'prop-types';
 import { Search } from "lucide-react";
 import { useState, useEffect } from 'react';
 import { useNavigate } from "react-router-dom";
+import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
+import { useLanguage } from "../../util/LanguageContext.jsx";
 
 export default function SearchContainer({searchTerm} ) { 
     const navigate = useNavigate();
+    const { language } = useLanguage();
     const [ inputSearchTerm, setInputSearchTerm ] = useState(searchTerm);
-    const [value, setValue] = useState(searchTerm || ''); 
+    const [value, setValue] = useState(searchTerm || '');
+    const [placeholder, setPlaceholder] = useState("Search news");
+    const [searchLabel, setSearchLabel] = useState("Search");
 
     useEffect(() => {
         setInputSearchTerm(searchTerm);
         setValue(searchTerm);
     }, [searchTerm]);
+
+    useEffect(() => {
+        const translate = async () => {
+            const [p, s] = await Promise.all([
+                fetchTranslatedText("뉴스 검색", language),
+                fetchTranslatedText("검색", language),
+            ]);
+            setPlaceholder(p);
+            setSearchLabel(s);
+        };
+        translate();
+    }, [language]);
     
     function handleSearch() {
         const keyword = inputSearchTerm.trim();
@@ -44,7 +61,7 @@ export default function SearchContainer({searchTerm} ) {
                     <input 
                         className={styled['searchContainer--Input']}
                         value={value}
-                        placeholder={'Search news'}
+                        placeholder={placeholder}
                         onChange={handleInputChange}
                         onKeyDown={handleKeyDown}
                     ></input>
@@ -54,7 +71,7 @@ export default function SearchContainer({searchTerm} ) {
                     className={styled['searchContainer--searchButton']}
                     onClick={handleClickSearch}
                     disabled={!value.trim()}
-                >Search</button>
+                >{searchLabel}</button>
             </div>
             
         </div>

--- a/FrontEnd/src/components/mainPage/SearchContainer.module.css
+++ b/FrontEnd/src/components/mainPage/SearchContainer.module.css
@@ -55,17 +55,95 @@
     color: #f0c040;
 }
 
+.input-wrapper {
+    position: relative;
+    flex: 1;
+    height: 100%;
+    display: flex;
+    align-items: center;
+}
+
 .searchContainer--Input{
-    margin-left: 10px;
+    padding-left: 10px;
     font-size: 18px;
     border: none;
     outline: none;
-    width: 95%;
+    width: 100%;
     height: 80%;
+    background: transparent;
+    position: relative;
+    z-index: 1;
 }
-.searchContainer--Input::placeholder{
+
+.animated-placeholder {
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    pointer-events: none;
+    user-select: none;
+    white-space: nowrap;
+    z-index: 0;
+}
+
+.placeholder-text {
     color: #565656;
     font-weight: bold;
+    font-size: 18px;
+}
+
+/* 이모지: 기본은 울고있는 상태, 컨테이너 호버 시 행복한 상태로 전환 */
+.emoji-sad,
+.emoji-happy {
+    font-size: 16px;
+}
+
+.emoji-happy {
+    display: none;
+}
+
+.searchContainer--searchInputContainer:hover .emoji-sad {
+    display: none;
+}
+
+.searchContainer--searchInputContainer:hover .emoji-happy {
+    display: inline;
+}
+
+/* 검색 버튼 내 점 애니메이션 그룹 */
+
+.btn-dots {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.btn-dot {
+    display: inline-block;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.7);
+    flex-shrink: 0;
+    animation: dotBounce 1.5s infinite ease-in-out;
+}
+
+.searchContainer--searchButton:disabled .btn-dot {
+    background-color: rgba(100, 100, 100, 0.4);
+}
+
+@keyframes dotBounce {
+    0%, 55%, 100% {
+        transform: translateY(0);
+        opacity: 0.3;
+    }
+    27% {
+        transform: translateY(-4px);
+        opacity: 1;
+    }
 }
 
 .searchContainer--searchButton{
@@ -80,6 +158,10 @@
     outline: none;
     box-shadow: 3px 3px 5px #a7a7a7;
     transition: background-color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
 }
 
 .searchContainer--searchButton:hover {

--- a/FrontEnd/src/components/newsCard/NewsCard.module.css
+++ b/FrontEnd/src/components/newsCard/NewsCard.module.css
@@ -122,20 +122,18 @@
     margin:0;
     font-size: 9px;
     font-weight: 600;
-    transition: text-decoration 0.3s ease;
 }
 
 .basicNewsCard--contents__title{
     margin:0;
     font-size: 15px;
     font-weight: 600;
-    transition: text-decoration 0.3s ease;
 
     /* 말줄임표 (...) 적용 */
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    width: 100%; /* 필요하면 조절 */
+    width: 100%;
 }
 
 .basicNewsCard--contents__preview{
@@ -143,7 +141,6 @@
     font-size: 11px;
     font-weight: 300;
     line-height: 13px;
-    transition: text-decoration 0.3s ease;
 
     /* 말줄임표 (...) 적용 */
     display: -webkit-box;
@@ -157,11 +154,13 @@
     margin: 3px 0;
     font-size: 10px;
     font-weight: 300;
-    transition: text-decoration 0.3s ease;
 }
 
-.basicNewsCard--contents__letterContainer:hover {
+/* 카드 호버 시 제목 밑줄 */
+.basicNewsCard--container:hover .basicNewsCard--contents__title {
     text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
 }
 
 .basicNewsCard--imageContainer{
@@ -217,9 +216,9 @@
     cursor: pointer;
 }
 
-.searchNewsCard--container:hover {
-    background-color: rgba(0, 0, 0, 0.3); /* 전체 배경 어두워짐 */
-    filter: brightness(0.7); /* 전체 밝기 어두워짐 */
+/* 카드 호버 시 제목 밑줄 */
+.searchNewsCard--container:hover .searchNewsCard--contents__title {
+    text-decoration: underline;
 }
 
 
@@ -244,7 +243,7 @@
     font-size: 17px;
     margin: 0;
     display: -webkit-box;
-    -webkit-line-clamp: 2;        /* 2줄까지만 표시 */
+    -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
     overflow: hidden;
     word-break: break-word;

--- a/FrontEnd/src/index.css
+++ b/FrontEnd/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Pretendard Variable', Pretendard, -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 

--- a/FrontEnd/src/layouts/MainLayout.jsx
+++ b/FrontEnd/src/layouts/MainLayout.jsx
@@ -5,13 +5,14 @@ import styles from './MainLayout.module.css';
 
 import Footer from '../components/commons/footer/Footer';
 import Header from '../components/commons/header/Header';
+import ChatHistoryButton from '../components/chat/ChatHistoryButton';
 
 export default function MainLayout() {
   const location = useLocation();
 
   const isIntroPage = location.pathname === "/intro";
-
-  const isFooterVisible = location.pathname !== "/"; // /일 때 footer 숨기기
+  const isLandingPage = location.pathname === "/";
+  const isFooterVisible = !isLandingPage;
 
   return (
     <div 
@@ -22,6 +23,7 @@ export default function MainLayout() {
       <Header />
       <Outlet />
       {isFooterVisible && <Footer />}
+      <ChatHistoryButton />
     </div>
   );
 }


### PR DESCRIPTION
## 🗂 관련 이슈
closes #69

## ✅ 작업 내용

### feat: 채팅 히스토리 연동 및 플로팅 버튼
- `/api/user/chat-history`, `/api/articles/{id}/chat-history` BE API 연동
- 우하단 플로팅 버튼(FAB) 추가 — 로그인 시 기사별 마지막 대화 미리보기 팝업 표시
- 비로그인 시 플로팅 버튼 유지하되 로그인 유도 메시지 + Google 로그인 버튼 노출

### feat: 챗봇 이전 대화 내역 불러오기 및 비로그인 안내
- 상세 페이지 챗봇 진입 시 로그인 상태면 해당 기사의 이전 대화 내역 자동 로드
- 이전 대화 / 새 대화 구분선(divider) 표시
- 비로그인 시 "로그인하면 대화 내역이 저장되고 문맥이 이어집니다." 안내 노출

### style: 마크다운 렌더링 적용
- `react-markdown` 적용 — 챗봇 응답, 기사 AI 요약, 채팅 히스토리 미리보기에서 `**bold**`, 줄바꿈, 목록 등 정상 렌더링

### style: 헤더 UI 개선
- 로그인 닉네임 골드 강조 + 전구 이모지(💡) 추가
- 로그인 버튼 골드 테두리, 로그아웃 버튼 은은한 회색 스타일 적용
- 언어 드롭다운 네이티브 `<select>` → 커스텀 `LanguageSelect` 컴포넌트로 교체
  - 랜딩/인트로 페이지: 다크 테마 (어두운 배경, 흰 글씨)
  - 그 외 페이지: 라이트 테마 (흰 배경, 짙은 글씨)
  - fade-in 등장 애니메이션, 화살표 회전, 라운드 패널, 커스텀 스크롤바
- Pretendard Variable 폰트 CDN 적용

### style: 검색창 UX 개선
- placeholder를 커스텀 오버레이로 교체 — "검색어를 입력해주세요 ! 😢" 표시
  - 마우스 오버 시 😢 → 🥰 이모지 전환 (CSS hover)
  - 포커스 / 입력 시 오버레이 사라짐
- 검색 버튼에 통통 튀는 점 세 개 애니메이션 추가 (비활성화 시 반투명)
- placeholder 및 버튼 텍스트 전역 언어 설정에 따라 자동 번역

### style: 카드 호버 효과 수정
- `BasicNewsCard`, `SearchNewsCard` 제목 hover 밑줄 미적용 버그 수정
  (`transition: text-decoration` 미지원 속성 제거)

## 📸 주요 변경 화면
- 채팅 히스토리 플로팅 버튼 팝업
- 커스텀 언어 드롭다운 (라이트/다크)
- 검색창 애니메이션 placeholder

## 🔍 테스트 방법
1. 로그인 후 기사 상세 페이지에서 챗봇 질문 → 재진입 시 이전 대화 내역 확인
2. 우하단 플로팅 버튼 클릭 → 대화 목록 팝업 확인 (비로그인 시 로그인 유도)
3. 헤더 언어 드롭다운 클릭 → 페이지별 테마 확인
4. 검색창 hover/focus 동작 확인