### PR TITLE
[FEAT] 스크랩 기능 DB 연동 (로그인/비로그인 분기)

### DIFF
--- a/FrontEnd/src/api/scrapAPI.js
+++ b/FrontEnd/src/api/scrapAPI.js
@@ -1,0 +1,34 @@
+import { authAPI } from "./authAPI";
+
+// 스크랩 토글 (로그인 필요) → { scrapped: true/false }
+export const toggleScrap = async (articleId) => {
+    try {
+        const response = await authAPI.post(`/api/articles/${articleId}/scrap`);
+        return response.data?.data?.scrapped ?? false;
+    } catch (error) {
+        console.error("스크랩 토글 실패:", error);
+        return null;
+    }
+};
+
+// 내 스크랩 목록 (로그인 필요) → ScrapListResDTO[]
+export const getMyScrapList = async () => {
+    try {
+        const response = await authAPI.get("/api/user/scraps");
+        return response.data?.data ?? [];
+    } catch (error) {
+        console.error("스크랩 목록 조회 실패:", error);
+        return [];
+    }
+};
+
+// 특정 기사 스크랩 여부 (로그인 필요) → true/false
+export const getScrapStatus = async (articleId) => {
+    try {
+        const response = await authAPI.get(`/api/articles/${articleId}/scrap/status`);
+        return response.data?.data?.scrapped ?? false;
+    } catch (error) {
+        console.error("스크랩 상태 조회 실패:", error);
+        return false;
+    }
+};

--- a/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
+++ b/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
@@ -5,37 +5,90 @@ import { MutatingDots } from "react-loader-spinner";
 import ReactMarkdown from "react-markdown";
 
 import TranslatedText from "../../api/TranslatedText.jsx";
+import { useAuth } from "../../util/AuthContext.jsx";
+import { toggleScrap, getScrapStatus } from "../../api/scrapAPI.js";
 
 export default function ArticleDetail({ id, newsDetail, content, isLoading, isSummaryLoading }) {
   const articleId = Number(id);
-  const { title, author, sourceName, publishedAt, viewCount, urlToImage } =
-    newsDetail;
+  const { title, author, sourceName, publishedAt, viewCount, urlToImage } = newsDetail;
+  const { token } = useAuth();
 
-    const [isScrapped, setIsScrapped] = useState(false);
+  const [isScrapped, setIsScrapped] = useState(false);
+  const [showModal, setShowModal] = useState(false);
 
-    useEffect(() => {
-      const storedScrapIds = JSON.parse(localStorage.getItem("scrapIds")) || [];
-      setIsScrapped(storedScrapIds.includes(articleId));
-    }, [articleId]);
+  useEffect(() => {
+    const initScrapStatus = async () => {
+      if (token) {
+        const status = await getScrapStatus(articleId);
+        setIsScrapped(status);
+      } else {
+        const storedScrapIds = JSON.parse(localStorage.getItem("scrapIds")) || [];
+        setIsScrapped(storedScrapIds.includes(articleId));
+      }
+    };
+    initScrapStatus();
+  }, [articleId, token]);
 
+  // 버튼 클릭 → 모달 열기
   function clickScrapBTN() {
-    const storedScrapIds = JSON.parse(localStorage.getItem('scrapIds')) || [];
+    setShowModal(true);
+  }
 
-    if (!storedScrapIds.includes(articleId)) {
+  // 모달에서 확인 → 실제 스크랩 토글
+  async function handleConfirmScrap() {
+    setShowModal(false);
+    if (token) {
+      const result = await toggleScrap(articleId);
+      if (result !== null) setIsScrapped(result);
+    } else {
+      const storedScrapIds = JSON.parse(localStorage.getItem("scrapIds")) || [];
+      if (!storedScrapIds.includes(articleId)) {
         storedScrapIds.push(articleId);
-        localStorage.setItem('scrapIds', JSON.stringify(storedScrapIds)); // 키 수정
+        localStorage.setItem("scrapIds", JSON.stringify(storedScrapIds));
         setIsScrapped(true);
-    }
-    else{
-        // articleId가 배열에 있는 경우 제거
-        const updatedScrapIds = storedScrapIds.filter(id => id !== articleId);
-        localStorage.setItem('scrapIds', JSON.stringify(updatedScrapIds));
+      } else {
+        const updatedScrapIds = storedScrapIds.filter((id) => id !== articleId);
+        localStorage.setItem("scrapIds", JSON.stringify(updatedScrapIds));
         setIsScrapped(false);
+      }
     }
   }
 
+  // 제목 말줄임 (모달용)
+  const shortTitle = title && title.length > 22 ? title.slice(0, 22) + "..." : title;
+
   return (
     <div className={styles.articleDetail}>
+
+      {/* 스크랩 확인 모달 */}
+      {showModal && (
+        <div className={styles.modalOverlay} onClick={() => setShowModal(false)}>
+          <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.modalIcon}>
+              <FaBookmark className={isScrapped ? styles.modalIconActive : styles.modalIconDefault} />
+            </div>
+            <p className={styles.modalMessage}>
+              <span className={styles.modalPress}>{sourceName}</span>
+              <br />
+              <span className={styles.modalTitle}>「{shortTitle}」</span>
+              <br />
+              <TranslatedText text={isScrapped ? "스크랩을 취소하시겠습니까?" : "기사를 스크랩하시겠습니까?"} />
+            </p>
+            <div className={styles.modalButtons}>
+              <button className={styles.modalCancel} onClick={() => setShowModal(false)}>
+                <TranslatedText text="아니오" />
+              </button>
+              <button
+                className={`${styles.modalConfirm} ${isScrapped ? styles.modalConfirmRemove : ""}`}
+                onClick={handleConfirmScrap}
+              >
+                <TranslatedText text={isScrapped ? "취소하기" : "스크랩"} />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <h1><TranslatedText text={title}/></h1>
       <div className={styles.infoContainer}>
         <p className={styles.timeText}>
@@ -43,14 +96,14 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading, isSu
         </p>
         <div className={styles.stats}>
           <span><TranslatedText text="조회수"/>{viewCount}</span>
-          <button 
-            className={styles.scrap}
+          <button
+            className={`${styles.scrap} ${isScrapped ? styles.scrapActive : ""}`}
             onClick={clickScrapBTN}
-            >
-            <TranslatedText text="스크랩"/>
-            <FaBookmark 
-                className={`${styles.icon} ${isScrapped ? styles.active : ""}`} 
-              />
+          >
+            <FaBookmark className={`${styles.icon} ${isScrapped ? styles.active : ""}`} />
+            <span className={styles.scrapLabel}>
+              <TranslatedText text={isScrapped ? "스크랩됨" : "스크랩"} />
+            </span>
           </button>
         </div>
       </div>

--- a/FrontEnd/src/components/detailsPage/ArticleDetail.module.css
+++ b/FrontEnd/src/components/detailsPage/ArticleDetail.module.css
@@ -47,31 +47,177 @@
     color: #555;
   }
   
+  /* ── 스크랩 버튼 ── */
   .scrap {
-    outline: none;
-    border: none;
     display: flex;
     align-items: center;
-    gap: 5px;
+    gap: 7px;
+    padding: 7px 14px;
+    border: 1.5px solid #ccc;
+    border-radius: 20px;
+    background: transparent;
     color: #555;
-    background-color: transparent;
-  }
-  .scrap:focus {
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
     outline: none;
+    transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
   }
-  
-  .icon {
-    color: transparent;
-    stroke: #555;
-    stroke-width: 50;
+
+  .scrap:hover {
+    border-color: #f0c040;
+    color: #b8860b;
+    background: rgba(240, 192, 64, 0.08);
+  }
+
+  .scrapActive {
+    border-color: #f0c040;
+    color: #b8860b;
+    background: rgba(240, 192, 64, 0.12);
+  }
+
+  .scrapLabel {
     font-size: 13px;
+  }
+
+  .icon {
+    stroke: #888;
+    stroke-width: 40;
+    font-size: 15px;
     fill: transparent;
     transition: all 0.2s ease;
   }
 
   .active {
-    fill: rgb(255, 185, 33);
+    fill: #f0c040;
     stroke: none;
+  }
+
+  /* ── 스크랩 확인 모달 ── */
+  .modalOverlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 300;
+    animation: fadeIn 0.18s ease;
+  }
+
+  @keyframes fadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  .modal {
+    background: #fff;
+    border-radius: 18px;
+    padding: 32px 28px 24px;
+    width: 340px;
+    max-width: 90vw;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    animation: slideUp 0.2s ease;
+  }
+
+  @keyframes slideUp {
+    from { transform: translateY(16px); opacity: 0; }
+    to   { transform: translateY(0);    opacity: 1; }
+  }
+
+  .modalIcon {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    background: rgba(240, 192, 64, 0.12);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .modalIconDefault {
+    font-size: 22px;
+    color: #ccc;
+  }
+
+  .modalIconActive {
+    font-size: 22px;
+    color: #f0c040;
+  }
+
+  .modalMessage {
+    text-align: center;
+    font-size: 15px;
+    color: #333;
+    line-height: 1.7;
+    margin: 0;
+  }
+
+  .modalPress {
+    font-size: 13px;
+    color: #888;
+    font-weight: 500;
+  }
+
+  .modalTitle {
+    font-weight: 700;
+    color: #111;
+    font-size: 15px;
+  }
+
+  .modalButtons {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+    margin-top: 4px;
+  }
+
+  .modalCancel {
+    flex: 1;
+    padding: 10px 0;
+    border: 1.5px solid #ddd;
+    border-radius: 10px;
+    background: transparent;
+    color: #888;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease;
+  }
+
+  .modalCancel:hover {
+    border-color: #aaa;
+    color: #555;
+  }
+
+  .modalConfirm {
+    flex: 1;
+    padding: 10px 0;
+    border: none;
+    border-radius: 10px;
+    background: #f0c040;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.15s ease;
+  }
+
+  .modalConfirm:hover {
+    background: #d4a820;
+    transform: translateY(-1px);
+  }
+
+  .modalConfirmRemove {
+    background: #ff6b6b;
+  }
+
+  .modalConfirmRemove:hover {
+    background: #e05555;
   }
   
 

--- a/FrontEnd/src/components/newsCard/NewsCard.module.css
+++ b/FrontEnd/src/components/newsCard/NewsCard.module.css
@@ -413,19 +413,143 @@
 }
 
 
-/* 별 아이콘 기본 스타일 */
-.ScrapNewsCard--star {
+/* ── 삭제 버튼 (× 원형) ── */
+.ScrapNewsCard--removeBtn {
     position: absolute;
     top: 8px;
-    right: 14px;
-    width: 24px;
-    height: 24px;
+    right: 8px;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    border: none;
+    background: rgba(0, 0, 0, 0.35);
+    color: rgba(255, 255, 255, 0.85);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
     cursor: pointer;
-    transition: transform 0.2s ease;
+    transition: background 0.2s ease, transform 0.15s ease;
+    z-index: 2;
 }
 
-.ScrapNewsCard--star:hover {
-    transform: scale(1.1);
+.ScrapNewsCard--removeBtn:hover {
+    background: rgba(220, 53, 53, 0.85);
+    color: #fff;
+    transform: scale(1.12);
+}
+
+/* ── 스크랩 취소 확인 모달 ── */
+.scrapModal--overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 300;
+    animation: scrapFadeIn 0.18s ease;
+}
+
+@keyframes scrapFadeIn {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+}
+
+.scrapModal {
+    background: #fff;
+    border-radius: 18px;
+    padding: 28px 24px 20px;
+    width: 320px;
+    max-width: 90vw;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 14px;
+    animation: scrapSlideUp 0.2s ease;
+}
+
+@keyframes scrapSlideUp {
+    from { transform: translateY(14px); opacity: 0; }
+    to   { transform: translateY(0);    opacity: 1; }
+}
+
+.scrapModal--icon {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: rgba(255, 100, 100, 0.1);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.scrapModal--bookmark {
+    font-size: 20px;
+    color: #f0c040;
+}
+
+.scrapModal--message {
+    text-align: center;
+    font-size: 14px;
+    color: #333;
+    line-height: 1.7;
+    margin: 0;
+}
+
+.scrapModal--press {
+    font-size: 12px;
+    color: #888;
+    font-weight: 500;
+}
+
+.scrapModal--title {
+    font-weight: 700;
+    color: #111;
+    font-size: 14px;
+}
+
+.scrapModal--buttons {
+    display: flex;
+    gap: 10px;
+    width: 100%;
+}
+
+.scrapModal--cancel {
+    flex: 1;
+    padding: 9px 0;
+    border: 1.5px solid #ddd;
+    border-radius: 10px;
+    background: transparent;
+    color: #888;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.scrapModal--cancel:hover {
+    border-color: #aaa;
+    color: #555;
+}
+
+.scrapModal--confirm {
+    flex: 1;
+    padding: 9px 0;
+    border: none;
+    border-radius: 10px;
+    background: #ff6b6b;
+    color: #fff;
+    font-size: 13px;
+    font-weight: 700;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.scrapModal--confirm:hover {
+    background: #e05555;
+    transform: translateY(-1px);
 }
 
 

--- a/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
@@ -1,62 +1,105 @@
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 import styled from "./NewsCard.module.css";
 import { useNavigate } from "react-router-dom";
 import TranslatedText from '../../api/TranslatedText';
-
-import StarFilled from "../../assets/icons/star_filled.svg";
-import StarBlank from "../../assets/icons/star_blank.svg";
+import { useAuth } from '../../util/AuthContext';
+import { toggleScrap as toggleScrapAPI } from '../../api/scrapAPI';
+import { FaBookmark, FaTimes } from 'react-icons/fa';
 
 export default function ScrapNewsCard({ id, press, title, summary, image, year, month, day, isScrapped, setIsScrapped }) {
     const articleId = id;
-    
+    const { token } = useAuth();
     const navigate = useNavigate();
+    const [showModal, setShowModal] = useState(false);
+
+    const shortTitle = title && title.length > 20 ? title.slice(0, 20) + "..." : title;
 
     function handleClickNewsCard(){
         navigate(`/detail/${id}`);
     }
 
+    function handleRemoveClick(e) {
+        e.stopPropagation();
+        setShowModal(true);
+    }
 
-    const toggleScrap = (e) => {
-        e.stopPropagation();  // 부모 div 클릭 이벤트 방지
-        setIsScrapped(!isScrapped);
+    async function handleConfirmRemove(e) {
+        e.stopPropagation();
+        setShowModal(false);
+        if (token) {
+            await toggleScrapAPI(articleId);
+        } else {
+            const storedScrapIds = JSON.parse(localStorage.getItem('scrapIds')) || [];
+            const updatedScrapIds = storedScrapIds.filter((sid) => Number(sid) !== Number(articleId));
+            localStorage.setItem('scrapIds', JSON.stringify(updatedScrapIds));
+        }
+        setIsScrapped(false);
+    }
 
-        const storedScrapIds = JSON.parse(localStorage.getItem('scrapIds')) || [];
-
-        // articleId가 배열에 있는 경우 제거
-        const updatedScrapIds = storedScrapIds.filter(id => id !== articleId);
-
-        localStorage.setItem('scrapIds', JSON.stringify(updatedScrapIds));
-    };
+    function handleCancelModal(e) {
+        e.stopPropagation();
+        setShowModal(false);
+    }
 
     return(
-        <div className={styled['ScrapNewsCard--container']} onClick={handleClickNewsCard}>
-            <div 
-                className={styled['ScrapNewsCard--image']}
-                style={image ? { backgroundImage: `url(${image})` } : {}} 
-            ></div>
-            <div className={styled['ScrapNewsCard--contents']}>
-                <div className={styled['ScrapNewsCard--contents__letterContainer']}>
-                    <p className={styled['ScrapNewsCard--contents__press']}>{press}</p>
-                    <p className={styled['ScrapNewsCard--contents__title']}>
-                        <TranslatedText text={title}/>
-                    </p>
-                    <p className={styled['ScrapNewsCard--contents__preview']}>
-                        <TranslatedText text={summary}/>
-                    </p>
+        <>
+            {/* 스크랩 취소 확인 모달 */}
+            {showModal && (
+                <div className={styled['scrapModal--overlay']} onClick={handleCancelModal}>
+                    <div className={styled['scrapModal']} onClick={(e) => e.stopPropagation()}>
+                        <div className={styled['scrapModal--icon']}>
+                            <FaBookmark className={styled['scrapModal--bookmark']} />
+                        </div>
+                        <p className={styled['scrapModal--message']}>
+                            <span className={styled['scrapModal--press']}>{press}</span>
+                            <br />
+                            <span className={styled['scrapModal--title']}>「{shortTitle}」</span>
+                            <br />
+                            <TranslatedText text="스크랩을 취소하시겠습니까?" />
+                        </p>
+                        <div className={styled['scrapModal--buttons']}>
+                            <button className={styled['scrapModal--cancel']} onClick={handleCancelModal}>
+                                <TranslatedText text="아니오" />
+                            </button>
+                            <button className={styled['scrapModal--confirm']} onClick={handleConfirmRemove}>
+                                <TranslatedText text="취소하기" />
+                            </button>
+                        </div>
+                    </div>
                 </div>
-                
-                <div className={styled['ScrapNewsCard--contents__dateContainer']}>
-                    <p className={styled['ScrapNewsCard--contents__date']}>{year}.{month}.{day}</p>
+            )}
+
+            <div className={styled['ScrapNewsCard--container']} onClick={handleClickNewsCard}>
+                <div
+                    className={styled['ScrapNewsCard--image']}
+                    style={image ? { backgroundImage: `url(${image})` } : {}}
+                />
+                <div className={styled['ScrapNewsCard--contents']}>
+                    <div className={styled['ScrapNewsCard--contents__letterContainer']}>
+                        <p className={styled['ScrapNewsCard--contents__press']}>{press}</p>
+                        <p className={styled['ScrapNewsCard--contents__title']}>
+                            <TranslatedText text={title}/>
+                        </p>
+                        <p className={styled['ScrapNewsCard--contents__preview']}>
+                            <TranslatedText text={summary}/>
+                        </p>
+                    </div>
+                    <div className={styled['ScrapNewsCard--contents__dateContainer']}>
+                        <p className={styled['ScrapNewsCard--contents__date']}>{year}.{month}.{day}</p>
+                    </div>
                 </div>
+
+                {/* 삭제 버튼 (× 원형) */}
+                <button
+                    className={styled['ScrapNewsCard--removeBtn']}
+                    onClick={handleRemoveClick}
+                    title="스크랩 취소"
+                >
+                    <FaTimes />
+                </button>
             </div>
-            
-            <img 
-                src={isScrapped ? StarFilled : StarBlank} 
-                alt="스크랩 버튼"
-                className={styled['ScrapNewsCard--star']}
-                onClick={toggleScrap}
-            />
-        </div>
+        </>
     )
 
 
@@ -77,7 +120,7 @@ ScrapNewsCard.propTypes = {
     year: PropTypes.string.isRequired,
     month: PropTypes.string.isRequired,
     day: PropTypes.string.isRequired,
-    isScrapped: PropTypes.bool.isRequired,
+    isScrapped: PropTypes.bool,
     setIsScrapped: PropTypes.func.isRequired,
 };
 

--- a/FrontEnd/src/pages/ScrapPage.jsx
+++ b/FrontEnd/src/pages/ScrapPage.jsx
@@ -1,49 +1,75 @@
 import styled from './ScrapPage.module.css';
-import { useState,useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import ScrapNewsCard from '../components/newsCard/ScrapNewsCard';
 import Pagenation from '../components/mainPage/Pagenation';
 import BlankNews from '../components/mainPage/BlankNews';
 import { getScrap } from '../api/getNewsCardAPI';
+import { getMyScrapList } from '../api/scrapAPI';
+import { useAuth } from '../util/AuthContext';
 
 export default function ScrapPage() {
     const [scrapNews, setScrapNews] = useState([]);
     const [scrapPage, setScrapPage] = useState(1);
     const [totalPages, setTotalPages] = useState(1);
     const [isScrapped, setIsScrapped] = useState(true);
+    const { token } = useAuth();
     const newsPerPage = 12;
 
     useEffect(() => {
         async function fetchScrapNews() {
-            const storedScrapIds = JSON.parse(localStorage.getItem("scrapIds") || "[]");
-            const newTotalPages = Math.ceil(storedScrapIds.length / newsPerPage);
-            setTotalPages(newTotalPages);
-    
-            const startIdx = (scrapPage - 1) * newsPerPage;
-            const currentPageIds = storedScrapIds.slice(startIdx, startIdx + newsPerPage);
-    
-            if (currentPageIds.length > 0) {
-                const data = await getScrap(currentPageIds);
+            if (token) {
+                // 로그인: BE DB에서 스크랩 목록 조회
+                const data = await getMyScrapList();
+                const newTotalPages = Math.ceil(data.length / newsPerPage);
+                setTotalPages(newTotalPages);
 
-                const filteredData = data.filter(news => currentPageIds.includes(news.id));
-                setScrapNews(filteredData);
+                const startIdx = (scrapPage - 1) * newsPerPage;
+                const paginated = data.slice(startIdx, startIdx + newsPerPage);
+
+                // ScrapListResDTO → ScrapNewsCard props에 맞게 변환
+                const mapped = paginated.map((item) => {
+                    const date = item.publishedAt ? new Date(item.publishedAt) : null;
+                    return {
+                        id: item.articleId,
+                        sourceName: item.sourceName,
+                        title: item.title,
+                        description: item.description,
+                        urlToImage: item.urlToImage,
+                        year: date ? String(date.getFullYear()) : "",
+                        month: date ? String(date.getMonth() + 1).padStart(2, "0") : "",
+                        day: date ? String(date.getDate()).padStart(2, "0") : "",
+                    };
+                });
+                setScrapNews(mapped);
             } else {
-                setScrapNews([]);
-            }
+                // 비로그인: localStorage → BE /api/scrap
+                const storedScrapIds = JSON.parse(localStorage.getItem("scrapIds") || "[]");
+                const newTotalPages = Math.ceil(storedScrapIds.length / newsPerPage);
+                setTotalPages(newTotalPages);
 
+                const startIdx = (scrapPage - 1) * newsPerPage;
+                const currentPageIds = storedScrapIds.slice(startIdx, startIdx + newsPerPage);
+
+                if (currentPageIds.length > 0) {
+                    const data = await getScrap(currentPageIds);
+                    // Number() 캐스팅으로 타입 불일치 방지 (localStorage: number, API: Long → number)
+                    const pageIdSet = new Set(currentPageIds.map(Number));
+                    const filteredData = data.filter((news) => pageIdSet.has(Number(news.id)));
+                    setScrapNews(filteredData);
+                } else {
+                    setScrapNews([]);
+                }
+            }
             setIsScrapped(true);
         }
-    
+
         fetchScrapNews();
-    }, [scrapPage, isScrapped]);
+    }, [scrapPage, isScrapped, token]);
 
 
     return(
         <div className={styled['ScrapNews--container']}>
             <div className={styled['ScrapNews--Newscontainer']}>
-                <div className={styled['ScrapNews--titleContainer']}>
-                    <h1 className={styled['ScrapNews--title']}>My Scrap</h1>
-                </div>
-
                 <div className={styled['ScrapNews--News']}>
                     {scrapNews.length > 0 ? (
                         <div className={styled['ScrapNews--News__container']}>


### PR DESCRIPTION
## 🗂 관련 이슈
closes #71

## ✅ 작업 내용

### feat: 스크랩 DB 연동 (로그인/비로그인 분기)
- `scrapAPI.js` 신규 생성 — `toggleScrap`, `getMyScrapList`, `getScrapStatus` API 연동
- **ArticleDetail.jsx**: 로그인 시 `getScrapStatus()`로 초기 상태 조회, 클릭 시 `toggleScrap()` 호출 / 비로그인 시 기존 localStorage 방식 유지
- **ScrapPage.jsx**: 로그인 시 `getMyScrapList()`로 DB 목록 조회, 비로그인 시 localStorage → `GET /api/scrap` 방식 유지
- **ScrapNewsCard.jsx**: 로그인 시 `toggleScrap()` 호출로 DB에서 제거, 비로그인 시 localStorage 제거 유지

### fix: 비로그인 마이스크랩 빈 화면 버그
- localStorage ID(숫자)와 API 응답 ID 간 타입 불일치(`includes()` 실패) 수정
- `Set + Number()` 캐스팅으로 타입 안전 처리

### fix: ScrapService LazyInitializationException (BE)
- `getScrap()`에 `@Transactional(readOnly = true)` 추가
- `article.getSource().getSourceName()` 접근 시 Hibernate 세션 유지
- 빈 결과 시 예외 대신 빈 리스트 반환으로 변경

### style: 스크랩 버튼 디자인 개선 및 확인 모달
- 스크랩 버튼 → pill 형태 (아이콘 + 텍스트, 스크랩 상태 골드 강조)
- 스크랩 추가/취소 클릭 시 확인 모달 — 언론사명 + 제목 일부 표시
- 마이스크랩 카드 별표 SVG → 반투명 `×` 원형 버튼으로 교체, 호버 시 빨간 강조
- 마이스크랩 페이지 중복 타이틀 제거

## 🔍 테스트 방법
1. 로그인 후 기사 상세 → 스크랩 버튼 클릭 → 확인 모달 → 스크랩 상태 반영 확인
2. 마이스크랩 페이지 → DB 기반 목록 조회 확인
3. `×` 버튼 클릭 → 확인 모달 → 목록에서 제거 확인
4. 비로그인 상태에서 동일 흐름 → localStorage 기반 동작 확인