### PR TITLE
[Refactor/#73] 랜딩 지구본(cobe)·국기·시계 및 로고 툴팁·헤더 개선

### DIFF
--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -11,6 +11,7 @@
         "aos": "^2.3.4",
         "axios": "^1.8.4",
         "classnames": "^2.5.1",
+        "cobe": "^2.0.1",
         "framer-motion": "^12.6.3",
         "globe.gl": "^2.41.3",
         "lucide-react": "^0.483.0",
@@ -1943,6 +1944,12 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
+    "node_modules/cobe": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cobe/-/cobe-2.0.1.tgz",
+      "integrity": "sha512-aaa6vcIlaC8C1SF50LDH0Anybo/EAXnrxqe+bwvr4+YUtZydqjeBjTTD7ziCCkbRrRGSns3I3F6cZsf3W+L+ag==",
       "license": "MIT"
     },
     "node_modules/color-convert": {

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -13,6 +13,7 @@
     "aos": "^2.3.4",
     "axios": "^1.8.4",
     "classnames": "^2.5.1",
+    "cobe": "^2.0.1",
     "framer-motion": "^12.6.3",
     "globe.gl": "^2.41.3",
     "lucide-react": "^0.483.0",

--- a/FrontEnd/src/api/TranslatedText.jsx
+++ b/FrontEnd/src/api/TranslatedText.jsx
@@ -30,7 +30,8 @@ const setCache = (text, lang, result) => {
 
 const TranslatedText = ({ text }) => {
     const { language } = useLanguage();
-    const [translated, setTranslated] = useState("");
+    /* 첫 페인트부터 원문 표시 → 빈 칸 방지, 이후 번역으로 갱신 */
+    const [translated, setTranslated] = useState(() => text ?? "");
 
     useEffect(() => {
         const translate = async () => {

--- a/FrontEnd/src/components/commons/header/Header.jsx
+++ b/FrontEnd/src/components/commons/header/Header.jsx
@@ -21,6 +21,13 @@ export default function Header() {
 
   const isHome = location.pathname === "/" || location.pathname === "/intro";
 
+  const logoTooltipLabel =
+    language === "en"
+      ? "Live trends check"
+      : language === "ja"
+        ? "リアルタイムトレンド 確認"
+        : "실시간 트렌드 확인하기";
+
   const navItems = [
     { label: "메인페이지", path: "/main" },
     { label: "마이스크랩", path: "/scrap" },
@@ -39,13 +46,42 @@ export default function Header() {
           isHome ? styles.whiteText : styles.blackText
         } ${isHome ? styles.blackBackground : styles.whiteBackground}`}
       >
-        {/* 로고 */}
-        <div className={styles.logoContainer}>
-          <img
-            src={Logo}
-            className={styles.image}
-            onClick={() => navigate("/")}
-          />
+        {/* 로고 — 클릭 시 랜딩(실시간 트렌드) */}
+        <div
+          className={styles.logoContainer}
+          onClick={() => navigate("/")}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" || e.key === " ") {
+              e.preventDefault();
+              navigate("/");
+            }
+          }}
+          role="button"
+          tabIndex={0}
+          aria-label="홈 · 실시간 트렌드로 이동"
+        >
+          <img src={Logo} className={styles.image} alt="" draggable={false} />
+          <span
+            className={`${styles.logoTooltip} ${isHome ? styles.logoTooltipOnDark : styles.logoTooltipOnLight}`}
+          >
+            <svg
+              className={styles.logoTooltipCaret}
+              viewBox="0 0 22 12"
+              width="22"
+              height="12"
+              aria-hidden
+            >
+              <polygon points="11,1 21,11 1,11" className={styles.logoTooltipCaretFill} />
+              <path
+                d="M1 11 L11 1 L21 11"
+                fill="none"
+                strokeWidth="1"
+                strokeLinejoin="miter"
+                className={styles.logoTooltipCaretStroke}
+              />
+            </svg>
+            <span className={styles.logoTooltipText}>{logoTooltipLabel}</span>
+          </span>
         </div>
 
         {/* 데스크탑 네비게이션 */}
@@ -69,12 +105,18 @@ export default function Header() {
                 <span className={styles.nickname}>
                   {user?.nickname ?? ""} 💡
                 </span>
-                <button onClick={logout} className={`${styles.authButton} ${styles.logoutButton}`}>
+                <button
+                  onClick={logout}
+                  className={`${styles.authButton} ${styles.logoutButton}`}
+                >
                   <TranslatedText text="로그아웃" />
                 </button>
               </>
             ) : (
-              <button onClick={handleLogin} className={`${styles.authButton} ${styles.loginButton}`}>
+              <button
+                onClick={handleLogin}
+                className={`${styles.authButton} ${styles.loginButton}`}
+              >
                 <TranslatedText text="로그인" />
               </button>
             )}
@@ -105,7 +147,9 @@ export default function Header() {
       />
 
       {/* 모바일 사이드 메뉴 (우측 슬라이드) */}
-      <div className={`${styles.mobileMenu} ${menuOpen ? styles.mobileMenuOpen : ""}`}>
+      <div
+        className={`${styles.mobileMenu} ${menuOpen ? styles.mobileMenuOpen : ""}`}
+      >
         {navItems.map(({ label, path }) => (
           <p
             key={path}
@@ -121,12 +165,21 @@ export default function Header() {
               <span className={styles.mobileNickname}>
                 {user?.nickname ?? ""} 💡
               </span>
-              <button onClick={() => { logout(); setMenuOpen(false); }} className={`${styles.authButton} ${styles.logoutButton}`}>
+              <button
+                onClick={() => {
+                  logout();
+                  setMenuOpen(false);
+                }}
+                className={`${styles.authButton} ${styles.logoutButton}`}
+              >
                 <TranslatedText text="로그아웃" />
               </button>
             </>
           ) : (
-            <button onClick={handleLogin} className={`${styles.authButton} ${styles.loginButton}`}>
+            <button
+              onClick={handleLogin}
+              className={`${styles.authButton} ${styles.loginButton}`}
+            >
               <TranslatedText text="로그인" />
             </button>
           )}

--- a/FrontEnd/src/components/commons/header/Header.module.css
+++ b/FrontEnd/src/components/commons/header/Header.module.css
@@ -7,13 +7,14 @@
 
 .header {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) minmax(0, 1fr);
   align-items: center;
   width: 100%;
   padding: 5px 40px;
   position: relative;
   color: currentColor;
   box-sizing: border-box;
+  min-width: 0;
 }
 
 .header p {
@@ -26,6 +27,7 @@
   font-weight: bold;
   border-radius: 8px;
   transition: color 0.25s ease, background-color 0.25s ease, transform 0.25s ease;
+  white-space: nowrap;
 }
 
 .whiteBackground {
@@ -35,6 +37,7 @@
 .blackBackground {
   background-color: black;
 }
+
 
 
 .whiteText p,
@@ -130,6 +133,8 @@
   cursor: pointer;
   display: flex;
   align-items: center;
+  min-width: 0;
+  flex-shrink: 0;
 }
 
 .authContainer {
@@ -192,6 +197,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: nowrap;
+  gap: 0;
+  min-width: 0;
 }
 
 /* 우측 영역 - 우측 정렬 */
@@ -200,6 +208,8 @@
   align-items: center;
   justify-content: flex-end;
   gap: 8px;
+  min-width: 0;
+  flex-shrink: 0;
 }
 
 /* 햄버거 버튼 - 기본 숨김 */
@@ -337,8 +347,37 @@
   color: white;
 }
 
-/* 반응형: 768px 이하에서 햄버거 표시, 데스크탑 요소 숨김 */
-@media (max-width: 768px) {
+/* 좁은 데스크탑·태블릿 가로: 여백·글자 크기만 살짝 축소 (햄버거 전) */
+@media (max-width: 1200px) and (min-width: 1101px) {
+  .header {
+    padding: 5px 20px;
+  }
+
+  .header p {
+    margin: 0 10px;
+    font-size: 15px;
+    padding: 6px 10px;
+  }
+
+  .image {
+    width: 160px;
+    height: 36px;
+  }
+
+  .authContainer {
+    gap: 6px;
+  }
+
+  .nickname {
+    font-size: 13px;
+    max-width: 120px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+/* 반응형: 1100px 이하에서 햄버거 표시 (가로 줄일 때 메뉴 글자 세로 배치 방지) */
+@media (max-width: 1100px) {
   .desktopNav {
     display: none;
   }

--- a/FrontEnd/src/components/commons/header/Header.module.css
+++ b/FrontEnd/src/components/commons/header/Header.module.css
@@ -3,11 +3,13 @@
   top: 0px;
   width: 100%;
   z-index: 102;
+  overflow: visible;
 }
 
 .header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr) minmax(0, 1fr);
+  /* 1fr | auto | 1fr — 가운데 메뉴가 화면 중앙에 오고, 로고/우측은 균형 있게 양끝 */
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   width: 100%;
   padding: 5px 40px;
@@ -15,6 +17,7 @@
   color: currentColor;
   box-sizing: border-box;
   min-width: 0;
+  overflow: visible;
 }
 
 .header p {
@@ -133,8 +136,127 @@
   cursor: pointer;
   display: flex;
   align-items: center;
-  min-width: 0;
+  min-width: max-content;
   flex-shrink: 0;
+  position: relative;
+  overflow: visible;
+  z-index: 1;
+  justify-self: start;
+}
+
+.logoContainer:focus-visible {
+  outline: 2px solid #f0c040;
+  outline-offset: 4px;
+  border-radius: 10px;
+}
+
+/* 로고 호버 툴팁: 위가 아니라 로고 아래에 띄움 → 상단 overflow/뷰포트 클립 방지 */
+.logoTooltip {
+  position: absolute;
+  top: calc(100% + 10px);
+  bottom: auto;
+  left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  padding: 9px 14px;
+  font-size: 13px;
+  font-weight: 700;
+  font-family: "Pretendard Variable", Pretendard, system-ui, sans-serif;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  border-radius: 10px;
+  pointer-events: none;
+  z-index: 500;
+  visibility: hidden;
+  opacity: 1;
+  transition: transform 0.18s ease, visibility 0.18s;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+}
+
+.logoTooltipText {
+  position: relative;
+  z-index: 2;
+  display: block;
+  line-height: 1.4;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* 꼭짓점: SVG — 열린 path로 좌·우 변만 stroke (밑변 없음) */
+.logoTooltipCaret {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  margin-bottom: -1px;
+  display: block;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.logoTooltipCaretFill {
+  stroke: none;
+}
+
+.logoTooltipOnDark .logoTooltipCaretFill {
+  fill: #1e1e22;
+}
+
+.logoTooltipOnDark .logoTooltipCaretStroke {
+  stroke: rgba(240, 192, 64, 0.5);
+}
+
+.logoTooltipOnLight .logoTooltipCaretFill {
+  fill: #ffffff;
+}
+
+.logoTooltipOnLight .logoTooltipCaretStroke {
+  stroke: rgba(0, 0, 0, 0.22);
+}
+
+/* 상단은 통째 border-top 쓰면 삼각형 아래 가로선만 도드라짐 → 좌·우 구간만 선 분할 */
+.logoTooltipOnDark {
+  background-color: #1e1e22;
+  border-left: 1px solid rgba(240, 192, 64, 0.5);
+  border-right: 1px solid rgba(240, 192, 64, 0.5);
+  border-bottom: 1px solid rgba(240, 192, 64, 0.5);
+  border-top: none;
+  background-image: linear-gradient(
+      rgba(240, 192, 64, 0.5),
+      rgba(240, 192, 64, 0.5)
+    ),
+    linear-gradient(rgba(240, 192, 64, 0.5), rgba(240, 192, 64, 0.5));
+  background-size: calc(50% - 10px) 1px, calc(50% - 10px) 1px;
+  background-position: left top, right top;
+  background-repeat: no-repeat;
+}
+
+.logoTooltipOnDark .logoTooltipText {
+  color: #f0c040 !important;
+}
+
+.logoTooltipOnLight {
+  background-color: #ffffff;
+  border-left: 1px solid rgba(0, 0, 0, 0.14);
+  border-right: 1px solid rgba(0, 0, 0, 0.14);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.14);
+  border-top: none;
+  background-image: linear-gradient(rgba(0, 0, 0, 0.14), rgba(0, 0, 0, 0.14)),
+    linear-gradient(rgba(0, 0, 0, 0.14), rgba(0, 0, 0, 0.14));
+  background-size: calc(50% - 10px) 1px, calc(50% - 10px) 1px;
+  background-position: left top, right top;
+  background-repeat: no-repeat;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.logoTooltipOnLight .logoTooltipText {
+  color: #111111 !important;
+}
+
+@media (hover: hover) {
+  .logoContainer:hover .logoTooltip,
+  .logoContainer:focus-visible .logoTooltip {
+    visibility: visible;
+    transform: translateX(-50%) translateY(0);
+  }
 }
 
 .authContainer {
@@ -192,7 +314,7 @@
   opacity: 1 !important;
 }
 
-/* 데스크탑 네비게이션 - 정중앙 */
+/* 데스크탑 네비게이션 - 그리드 가운데 열 기준 화면 중앙 */
 .desktopNav {
   display: flex;
   align-items: center;
@@ -200,6 +322,7 @@
   flex-wrap: nowrap;
   gap: 0;
   min-width: 0;
+  justify-self: center;
 }
 
 /* 우측 영역 - 우측 정렬 */
@@ -210,6 +333,7 @@
   gap: 8px;
   min-width: 0;
   flex-shrink: 0;
+  justify-self: end;
 }
 
 /* 햄버거 버튼 - 기본 숨김 */

--- a/FrontEnd/src/components/globe/Globe.jsx
+++ b/FrontEnd/src/components/globe/Globe.jsx
@@ -1,148 +1,280 @@
 import { useEffect, useRef, useState } from "react";
-import Globe from "globe.gl";
-import countries from "world-countries";
+import createGlobe from "cobe";
 import TrendModal from "./TrendModal";
 import NewsModal from "./NewsModal";
 import { getTrend } from "../../api/landingPageAPI";
+import styles from "./Globe.module.css";
 
-const countryCodeMap = {
-  KR: "한국",
-  AU: "호주",
-  AT: "오스트리아",
-  BR: "브라질",
-  CA: "캐나다",
-  CO: "콜롬비아",
-  DK: "덴마크",
-  EG: "이집트",
-  FR: "프랑스",
-  DE: "독일",
-  GR: "그리스",
-  HK: "홍콩",
-  IN: "인도",
-  ID: "인도네시아",
-  IT: "이탈리아",
-  JP: "일본",
-  MY: "말레이시아",
-  MX: "멕시코",
-  NL: "네덜란드",
-  RU: "러시아",
-  SG: "싱가포르",
-  TW: "대만",
-  TR: "터키",
-  GB: "영국",
-  US: "미국",
-  ES: "스페인",
+const BASE_THETA = 0.3;
+
+// BE에서 실제 트렌드를 수집하는 26개 지원 국가
+const COUNTRY_MARKERS = {
+  KR: { lat: 35.9,  lng: 127.8,  name: "South Korea" },
+  JP: { lat: 36.2,  lng: 138.3,  name: "Japan" },
+  HK: { lat: 22.4,  lng: 114.1,  name: "Hong Kong" },
+  TW: { lat: 23.7,  lng: 121.0,  name: "Taiwan" },
+  SG: { lat: 1.4,   lng: 103.8,  name: "Singapore" },
+  MY: { lat: 4.2,   lng: 108.0,  name: "Malaysia" },
+  ID: { lat: -0.8,  lng: 113.9,  name: "Indonesia" },
+  IN: { lat: 20.6,  lng: 79.1,   name: "India" },
+  AU: { lat: -25.3, lng: 133.8,  name: "Australia" },
+  US: { lat: 37.1,  lng: -95.7,  name: "United States" },
+  CA: { lat: 56.1,  lng: -106.3, name: "Canada" },
+  MX: { lat: 23.6,  lng: -102.6, name: "Mexico" },
+  BR: { lat: -14.2, lng: -51.9,  name: "Brazil" },
+  CO: { lat: 4.6,   lng: -74.1,  name: "Colombia" },
+  GB: { lat: 55.4,  lng: -3.4,   name: "United Kingdom" },
+  FR: { lat: 46.2,  lng: 2.2,    name: "France" },
+  DE: { lat: 51.2,  lng: 10.5,   name: "Germany" },
+  IT: { lat: 41.9,  lng: 12.6,   name: "Italy" },
+  ES: { lat: 40.5,  lng: -3.7,   name: "Spain" },
+  NL: { lat: 52.1,  lng: 5.3,    name: "Netherlands" },
+  AT: { lat: 47.5,  lng: 14.6,   name: "Austria" },
+  DK: { lat: 56.3,  lng: 9.5,    name: "Denmark" },
+  GR: { lat: 39.1,  lng: 21.8,   name: "Greece" },
+  RU: { lat: 61.5,  lng: 105.3,  name: "Russia" },
+  TR: { lat: 38.9,  lng: 35.2,   name: "Turkey" },
+  EG: { lat: 26.8,  lng: 30.8,   name: "Egypt" },
 };
 
+/**
+ * 클릭/호버 감지 전용 투영 함수.
+ * CSS 앵커 포지셔닝이 라벨 위치를 담당하므로 여기선 좌표 계산만 사용.
+ */
+function projectMarker(lat, lng, phi, theta, canvasW, canvasH) {
+  const latR = (lat * Math.PI) / 180;
+  const lngR = (lng * Math.PI) / 180;
+  const x0 = Math.cos(latR) * Math.sin(lngR);
+  const y0 = Math.sin(latR);
+  const z0 = Math.cos(latR) * Math.cos(lngR);
+  const x1 = x0 * Math.cos(phi) + z0 * Math.sin(phi);
+  const z1 = -x0 * Math.sin(phi) + z0 * Math.cos(phi);
+  const y2 = y0 * Math.cos(theta) - z1 * Math.sin(theta);
+  const z2 = y0 * Math.sin(theta) + z1 * Math.cos(theta);
+  if (z2 < 0.05) return null;
+  const r = Math.min(canvasW, canvasH) / 2;
+  return { x: canvasW / 2 + x1 * r, y: canvasH / 2 - y2 * r, z: z2 };
+}
+
 const GlobeComponent = () => {
-  const globeRef = useRef(null);
+  const canvasRef = useRef(null);
+  const containerRef = useRef(null);
+  const labelElsRef = useRef({});
+  const phiRef = useRef(0);
+  const thetaRef = useRef(BASE_THETA);
   const trendModalRef = useRef(null);
   const newsModalRef = useRef(null);
-  const [selectedCountry, setSelectedCountry] = useState(null); // 선택한 국가 코드
-  const [trendData, setTrendData] = useState(null); // 트렌드 데이터 상태
-  const [selectedNews, setSelectedNews] = useState(null); // 선택한 뉴스 상태
+
+  const [selectedCountry, setSelectedCountry] = useState(null);
+  const [trendData, setTrendData] = useState(null);
+  const [selectedNews, setSelectedNews] = useState(null);
 
   useEffect(() => {
-    // 지구본 초기화
-    const globe = Globe()(globeRef.current)
-      .globeImageUrl(
-        "//unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
-      )
-      .bumpImageUrl("//unpkg.com/three-globe/example/img/earth-topology.png")
-      .backgroundImageUrl("//unpkg.com/three-globe/example/img/night-sky.png")
-      .pointOfView({ lat: 0, lng: 0, altitude: 2 });
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
 
-    globe.controls().autoRotate = true;
-    globe.controls().autoRotateSpeed = 0.5;
+    const getSize = () => ({
+      w: container.offsetWidth,
+      h: container.offsetHeight,
+    });
+    const { w, h } = getSize();
 
-    // 마커 데이터 설정
-    const markers = countries.map((country) => ({
-      lat: country.latlng[0],
-      lng: country.latlng[1],
-      countryCode: country.cca2,
-      label: country.name.common,
+    // cobe 마커에 id 부여 → CSS 앵커 포지셔닝용 --cobe-{id} 변수 생성
+    const cobeMarkers = Object.entries(COUNTRY_MARKERS).map(([code, { lat, lng }]) => ({
+      location: [lat, lng],
+      size: 0.03,
+      id: code.toLowerCase(),
     }));
 
-    globe
-      .pointsData(markers)
-      .pointLat((d) => d.lat)
-      .pointLng((d) => d.lng)
-      .pointAltitude(() => 0)
-      .pointRadius(() => 0.8)
-      .pointColor(() => "rgba(125, 231, 50, 0.5)")
-      .pointResolution(10)
-      .pointLabel((d) => d.label)
-      .onPointClick((marker) => {
-        const countryCode = marker.countryCode;
-        if (countryCodeMap[countryCode]) {
-          setSelectedCountry(countryCode);
+    const globe = createGlobe(canvas, {
+      devicePixelRatio: 2,
+      width: w * 2,
+      height: h * 2,
+      phi: 0,
+      theta: BASE_THETA,
+      dark: 0,
+      diffuse: 1.2,
+      mapSamples: 8000,
+      mapBrightness: 6,
+      mapBaseBrightness: 0,
+      baseColor: [1, 1, 1],
+      markerColor: [0.08, 0.08, 0.12],
+      glowColor: [0.8, 0.85, 1.0],
+      markers: cobeMarkers,
+    });
+
+    let phi = 0;
+    let currentTheta = BASE_THETA;
+    let targetTheta = BASE_THETA;
+    let autoRotate = true;
+    let rafId;
+
+    const animate = () => {
+      if (autoRotate) {
+        phi += 0.003;
+      }
+      currentTheta += (targetTheta - currentTheta) * 0.08;
+      phiRef.current = phi;
+      thetaRef.current = currentTheta;
+      globe.update({ phi, theta: currentTheta });
+      rafId = requestAnimationFrame(animate);
+    };
+    animate();
+
+    let dragStartX = null;
+    let dragStartPhi = 0;
+    let didDrag = false;
+
+    const onPointerDown = (e) => {
+      dragStartX = e.clientX;
+      dragStartPhi = phi;
+      didDrag = false;
+      autoRotate = false;
+      canvas.setPointerCapture(e.pointerId);
+    };
+
+    const onPointerMove = (e) => {
+      if (dragStartX !== null) {
+        const dx = e.clientX - dragStartX;
+        if (Math.abs(dx) > 4) didDrag = true;
+        phi = dragStartPhi + dx * 0.006;
+        phiRef.current = phi;
+        globe.update({ phi, theta: currentTheta });
+        return;
+      }
+      const rect = canvas.getBoundingClientRect();
+      const y = (e.clientY - rect.top) / rect.height;
+      targetTheta = BASE_THETA + (y - 0.5) * 0.5;
+
+      // 라벨 DOM 실제 위치 기준으로 hover cursor 설정
+      let near = false;
+      for (const el of Object.values(labelElsRef.current)) {
+        if (!el) continue;
+        const r = el.getBoundingClientRect();
+        if (r.width === 0) continue;
+        if (
+          e.clientX >= r.left - 12 && e.clientX <= r.right + 12 &&
+          e.clientY >= r.top - 12  && e.clientY <= r.bottom + 12
+        ) { near = true; break; }
+      }
+      canvas.style.cursor = near ? "pointer" : "default";
+    };
+
+    const onPointerUp = (e) => {
+      const wasDrag = didDrag;
+      dragStartX = null;
+      autoRotate = true;
+      if (!wasDrag) {
+        // 라벨 DOM 실제 위치로 클릭 감지 (수식 오차 없음)
+        let bestCode = null;
+        let minDist = Infinity;
+        const THRESHOLD = 50;
+        for (const [code, el] of Object.entries(labelElsRef.current)) {
+          if (!el) continue;
+          const r = el.getBoundingClientRect();
+          if (r.width === 0) continue;
+          const cx = r.left + r.width / 2;
+          const cy = r.top + r.height / 2;
+          const d = Math.hypot(e.clientX - cx, e.clientY - cy);
+          if (d < THRESHOLD && d < minDist) { minDist = d; bestCode = code; }
         }
-      });
-
-    const handleResize = () => {
-      globe.width([globeRef.current.offsetWidth]);
-      globe.height([globeRef.current.offsetHeight]);
+        if (bestCode) {
+          setSelectedCountry(bestCode);
+        } else {
+          setSelectedCountry(null);
+          setTrendData(null);
+          setSelectedNews(null);
+        }
+      }
     };
-  
-    window.addEventListener("resize", handleResize);
-    handleResize(); // 초기 사이즈 설정
 
-    // 모달 외부 클릭 시 닫기
-    const handleClickOutside = (event) => {
-      if (newsModalRef.current && newsModalRef.current.contains(event.target)) {
-        return;
-      }
-      if (
-        trendModalRef.current &&
-        trendModalRef.current.contains(event.target)
-      ) {
-        return;
-      }
+    const onPointerLeave = () => {
+      dragStartX = null;
+      autoRotate = true;
+      targetTheta = BASE_THETA;
+    };
+
+    const onDocMouseDown = (e) => {
+      if (e.target === canvas) return;
+      if (trendModalRef.current?.contains(e.target)) return;
+      if (newsModalRef.current?.contains(e.target)) return;
       setSelectedCountry(null);
+      setTrendData(null);
       setSelectedNews(null);
-      setTrendData(null); // 모달 닫을 때 트렌드 데이터 초기화
     };
 
-    document.addEventListener("mousedown", handleClickOutside);
+    const onResize = () => {
+      const { w: nw, h: nh } = getSize();
+      globe.update({ width: nw * 2, height: nh * 2 });
+    };
+
+    canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("pointermove", onPointerMove);
+    canvas.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("pointerleave", onPointerLeave);
+    document.addEventListener("mousedown", onDocMouseDown);
+    window.addEventListener("resize", onResize);
+
     return () => {
-      window.removeEventListener("resize", handleResize);
-      document.removeEventListener("mousedown", handleClickOutside);
+      cancelAnimationFrame(rafId);
+      globe.destroy();
+      canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("pointermove", onPointerMove);
+      canvas.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("pointerleave", onPointerLeave);
+      document.removeEventListener("mousedown", onDocMouseDown);
+      window.removeEventListener("resize", onResize);
     };
   }, []);
 
-  // 선택한 국가의 트렌드 데이터 불러오기
   useEffect(() => {
     if (selectedCountry) {
-      setTrendData(null); // 새로운 데이터 요청 전 초기화
+      setTrendData(null);
       getTrend(selectedCountry)
         .then((data) => setTrendData(data))
-        .catch(() => setTrendData([])); // 에러 발생 시 빈 배열 처리
+        .catch(() => setTrendData([]));
     }
   }, [selectedCountry]);
 
   return (
-    <div>
-      {/* 지구본 표시 */}
-      <div ref={globeRef} style={{ width: "100vw", height: "100vh" }} />
+    <div ref={containerRef} className={styles.globeContainer}>
+      <canvas
+        ref={canvasRef}
+        style={{ width: "100%", height: "100%", display: "block" }}
+      />
+
+      {/* cobe CSS 앵커 포지셔닝: --cobe-{id} 앵커에 자동 부착 */}
+      {Object.entries(COUNTRY_MARKERS).map(([code, { name }]) => (
+        <div
+          key={code}
+          ref={(el) => { labelElsRef.current[code] = el; }}
+          className={styles.markerLabel}
+          style={{
+            positionAnchor: `--cobe-${code.toLowerCase()}`,
+            opacity: `var(--cobe-visible-${code.toLowerCase()}, 0)`,
+          }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onClick={() => setSelectedCountry(code)}
+        >
+          {name}
+        </div>
+      ))}
 
       {selectedCountry && trendData && (
         <div ref={trendModalRef}>
           <TrendModal
-            country={countryCodeMap[selectedCountry]}
-            trends={trendData.data} // data 배열 전달
-            timestamp={trendData.timestamp} // timestamp 전달
+            country={COUNTRY_MARKERS[selectedCountry].name}
+            trends={trendData.data}
+            timestamp={trendData.timestamp}
             onSelect={(news) => setSelectedNews(news)}
-            onClose={() => setSelectedCountry(null)}
+            onClose={() => { setSelectedCountry(null); setTrendData(null); }}
           />
         </div>
       )}
 
       {selectedNews && (
         <div ref={newsModalRef}>
-          <NewsModal
-            news={selectedNews}
-            onClose={() => setSelectedNews(null)}
-          />
+          <NewsModal news={selectedNews} onClose={() => setSelectedNews(null)} />
         </div>
       )}
     </div>

--- a/FrontEnd/src/components/globe/Globe.jsx
+++ b/FrontEnd/src/components/globe/Globe.jsx
@@ -9,32 +9,32 @@ const BASE_THETA = 0.3;
 
 // BE에서 실제 트렌드를 수집하는 26개 지원 국가
 const COUNTRY_MARKERS = {
-  KR: { lat: 35.9,  lng: 127.8,  name: "South Korea" },
-  JP: { lat: 36.2,  lng: 138.3,  name: "Japan" },
-  HK: { lat: 22.4,  lng: 114.1,  name: "Hong Kong" },
-  TW: { lat: 23.7,  lng: 121.0,  name: "Taiwan" },
-  SG: { lat: 1.4,   lng: 103.8,  name: "Singapore" },
-  MY: { lat: 4.2,   lng: 108.0,  name: "Malaysia" },
-  ID: { lat: -0.8,  lng: 113.9,  name: "Indonesia" },
-  IN: { lat: 20.6,  lng: 79.1,   name: "India" },
-  AU: { lat: -25.3, lng: 133.8,  name: "Australia" },
-  US: { lat: 37.1,  lng: -95.7,  name: "United States" },
-  CA: { lat: 56.1,  lng: -106.3, name: "Canada" },
-  MX: { lat: 23.6,  lng: -102.6, name: "Mexico" },
-  BR: { lat: -14.2, lng: -51.9,  name: "Brazil" },
-  CO: { lat: 4.6,   lng: -74.1,  name: "Colombia" },
+  KR: { lat: 35.9,  lng: 127.8,  name: "South Korea"    },
+  JP: { lat: 36.2,  lng: 138.3,  name: "Japan"          },
+  HK: { lat: 22.4,  lng: 114.1,  name: "Hong Kong"      },
+  TW: { lat: 23.7,  lng: 121.0,  name: "Taiwan"         },
+  SG: { lat: 1.4,   lng: 103.8,  name: "Singapore"      },
+  MY: { lat: 4.2,   lng: 108.0,  name: "Malaysia"       },
+  ID: { lat: -0.8,  lng: 113.9,  name: "Indonesia"      },
+  IN: { lat: 20.6,  lng: 79.1,   name: "India"          },
+  AU: { lat: -25.3, lng: 133.8,  name: "Australia"      },
+  US: { lat: 37.1,  lng: -95.7,  name: "United States"  },
+  CA: { lat: 56.1,  lng: -106.3, name: "Canada"         },
+  MX: { lat: 23.6,  lng: -102.6, name: "Mexico"         },
+  BR: { lat: -14.2, lng: -51.9,  name: "Brazil"         },
+  CO: { lat: 4.6,   lng: -74.1,  name: "Colombia"       },
   GB: { lat: 55.4,  lng: -3.4,   name: "United Kingdom" },
-  FR: { lat: 46.2,  lng: 2.2,    name: "France" },
-  DE: { lat: 51.2,  lng: 10.5,   name: "Germany" },
-  IT: { lat: 41.9,  lng: 12.6,   name: "Italy" },
-  ES: { lat: 40.5,  lng: -3.7,   name: "Spain" },
-  NL: { lat: 52.1,  lng: 5.3,    name: "Netherlands" },
-  AT: { lat: 47.5,  lng: 14.6,   name: "Austria" },
-  DK: { lat: 56.3,  lng: 9.5,    name: "Denmark" },
-  GR: { lat: 39.1,  lng: 21.8,   name: "Greece" },
-  RU: { lat: 61.5,  lng: 105.3,  name: "Russia" },
-  TR: { lat: 38.9,  lng: 35.2,   name: "Turkey" },
-  EG: { lat: 26.8,  lng: 30.8,   name: "Egypt" },
+  FR: { lat: 46.2,  lng: 2.2,    name: "France"         },
+  DE: { lat: 51.2,  lng: 10.5,   name: "Germany"        },
+  IT: { lat: 41.9,  lng: 12.6,   name: "Italy"          },
+  ES: { lat: 40.5,  lng: -3.7,   name: "Spain"          },
+  NL: { lat: 52.1,  lng: 5.3,    name: "Netherlands"    },
+  AT: { lat: 47.5,  lng: 14.6,   name: "Austria"        },
+  DK: { lat: 56.3,  lng: 9.5,    name: "Denmark"        },
+  GR: { lat: 39.1,  lng: 21.8,   name: "Greece"         },
+  RU: { lat: 61.5,  lng: 105.3,  name: "Russia"         },
+  TR: { lat: 38.9,  lng: 35.2,   name: "Turkey"         },
+  EG: { lat: 26.8,  lng: 30.8,   name: "Egypt"          },
 };
 
 /**
@@ -68,6 +68,15 @@ const GlobeComponent = () => {
   const [selectedCountry, setSelectedCountry] = useState(null);
   const [trendData, setTrendData] = useState(null);
   const [selectedNews, setSelectedNews] = useState(null);
+  const [now, setNow] = useState(new Date());
+
+  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const city = timezone.split("/").pop().replace(/_/g, " ");
+
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), 1000);
+    return () => clearInterval(timer);
+  }, []);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -80,11 +89,13 @@ const GlobeComponent = () => {
     const { w, h } = getSize();
 
     // cobe 마커에 id 부여 → CSS 앵커 포지셔닝용 --cobe-{id} 변수 생성
-    const cobeMarkers = Object.entries(COUNTRY_MARKERS).map(([code, { lat, lng }]) => ({
-      location: [lat, lng],
-      size: 0.03,
-      id: code.toLowerCase(),
-    }));
+    const cobeMarkers = Object.entries(COUNTRY_MARKERS).map(
+      ([code, { lat, lng }]) => ({
+        location: [lat, lng],
+        size: 0.03,
+        id: code.toLowerCase(),
+      }),
+    );
 
     const globe = createGlobe(canvas, {
       devicePixelRatio: 2,
@@ -92,14 +103,14 @@ const GlobeComponent = () => {
       height: h * 2,
       phi: 0,
       theta: BASE_THETA,
-      dark: 0,
-      diffuse: 1.2,
-      mapSamples: 8000,
-      mapBrightness: 6,
-      mapBaseBrightness: 0,
-      baseColor: [1, 1, 1],
-      markerColor: [0.08, 0.08, 0.12],
-      glowColor: [0.8, 0.85, 1.0],
+      dark: 1,
+      diffuse: 1.5,
+      mapSamples: 12000,
+      mapBrightness: 3.5,
+      mapBaseBrightness: 0.05,
+      baseColor: [0.12, 0.18, 0.38],
+      markerColor: [0.98, 0.82, 0.2],
+      glowColor: [0.6, 0.65, 1.0],
       markers: cobeMarkers,
     });
 
@@ -153,9 +164,14 @@ const GlobeComponent = () => {
         const r = el.getBoundingClientRect();
         if (r.width === 0) continue;
         if (
-          e.clientX >= r.left - 12 && e.clientX <= r.right + 12 &&
-          e.clientY >= r.top - 12  && e.clientY <= r.bottom + 12
-        ) { near = true; break; }
+          e.clientX >= r.left - 12 &&
+          e.clientX <= r.right + 12 &&
+          e.clientY >= r.top - 12 &&
+          e.clientY <= r.bottom + 12
+        ) {
+          near = true;
+          break;
+        }
       }
       canvas.style.cursor = near ? "pointer" : "default";
     };
@@ -176,7 +192,10 @@ const GlobeComponent = () => {
           const cx = r.left + r.width / 2;
           const cy = r.top + r.height / 2;
           const d = Math.hypot(e.clientX - cx, e.clientY - cy);
-          if (d < THRESHOLD && d < minDist) { minDist = d; bestCode = code; }
+          if (d < THRESHOLD && d < minDist) {
+            minDist = d;
+            bestCode = code;
+          }
         }
         if (bestCode) {
           setSelectedCountry(bestCode);
@@ -247,8 +266,11 @@ const GlobeComponent = () => {
       {Object.entries(COUNTRY_MARKERS).map(([code, { name }]) => (
         <div
           key={code}
-          ref={(el) => { labelElsRef.current[code] = el; }}
+          ref={(el) => {
+            labelElsRef.current[code] = el;
+          }}
           className={styles.markerLabel}
+          data-name={name}
           style={{
             positionAnchor: `--cobe-${code.toLowerCase()}`,
             opacity: `var(--cobe-visible-${code.toLowerCase()}, 0)`,
@@ -256,9 +278,33 @@ const GlobeComponent = () => {
           onMouseDown={(e) => e.stopPropagation()}
           onClick={() => setSelectedCountry(code)}
         >
-          {name}
+          <img
+            src={`https://flagcdn.com/w20/${code.toLowerCase()}.png`}
+            srcSet={`https://flagcdn.com/w40/${code.toLowerCase()}.png 2x`}
+            alt={name}
+            className={styles.flagImg}
+            draggable={false}
+          />
+          <span className={styles.flagName}>{name}</span>
         </div>
       ))}
+
+      {/* 좌측 하단 실시간 로컬 시계 */}
+      <div className={styles.clockWidget}>
+        <div className={styles.clockCity}>{city}</div>
+        <div className={styles.clockTime}>
+          {now.toLocaleTimeString("en-GB", { hour12: false })}
+        </div>
+        <div className={styles.clockDate}>
+          {now.toLocaleDateString("en-GB", {
+            weekday: "short",
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          })}
+        </div>
+        <div className={styles.clockTz}>{timezone}</div>
+      </div>
 
       {selectedCountry && trendData && (
         <div ref={trendModalRef}>
@@ -267,14 +313,20 @@ const GlobeComponent = () => {
             trends={trendData.data}
             timestamp={trendData.timestamp}
             onSelect={(news) => setSelectedNews(news)}
-            onClose={() => { setSelectedCountry(null); setTrendData(null); }}
+            onClose={() => {
+              setSelectedCountry(null);
+              setTrendData(null);
+            }}
           />
         </div>
       )}
 
       {selectedNews && (
         <div ref={newsModalRef}>
-          <NewsModal news={selectedNews} onClose={() => setSelectedNews(null)} />
+          <NewsModal
+            news={selectedNews}
+            onClose={() => setSelectedNews(null)}
+          />
         </div>
       )}
     </div>

--- a/FrontEnd/src/components/globe/Globe.module.css
+++ b/FrontEnd/src/components/globe/Globe.module.css
@@ -1,0 +1,44 @@
+.globeContainer {
+  width: 100vw;
+  height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+/**
+ * CSS Anchor Positioning (Chrome 125+)
+ * cobe가 각 마커에 --cobe-{id} 앵커를 자동 설정함
+ * position-anchor는 JSX 인라인으로 국가별 개별 지정
+ */
+.markerLabel {
+  position: absolute;
+  bottom: anchor(top);
+  left: anchor(center);
+  translate: -50% 0;
+  margin-bottom: 10px;
+
+  padding: 2px 7px;
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  color: rgba(170, 120, 0, 0.95);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.55px;
+  text-transform: uppercase;
+  border-radius: 4px;
+  border: 1px solid rgba(240, 192, 64, 0.3);
+  white-space: nowrap;
+  pointer-events: auto;
+  cursor: pointer;
+  transition: opacity 0.2s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  transform-origin: center bottom;
+}
+
+.markerLabel:hover {
+  transform: scale(1.3);
+  background: rgba(255, 255, 255, 0.96);
+  border-color: rgba(240, 192, 64, 0.7);
+  box-shadow: 0 2px 10px rgba(240, 192, 64, 0.35);
+  z-index: 10;
+}

--- a/FrontEnd/src/components/globe/Globe.module.css
+++ b/FrontEnd/src/components/globe/Globe.module.css
@@ -3,6 +3,7 @@
   height: 100vh;
   position: relative;
   overflow: hidden;
+  background: #000000;
 }
 
 /**
@@ -17,16 +18,14 @@
   translate: -50% 0;
   margin-bottom: 10px;
 
-  padding: 2px 7px;
-  background: rgba(255, 255, 255, 0.82);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  color: rgba(170, 120, 0, 0.95);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.55px;
-  text-transform: uppercase;
-  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 7px 3px 4px;
+  background: rgba(0, 0, 0, 0.62);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  border-radius: 5px;
   border: 1px solid rgba(240, 192, 64, 0.3);
   white-space: nowrap;
   pointer-events: auto;
@@ -35,10 +34,81 @@
   transform-origin: center bottom;
 }
 
+.flagImg {
+  display: block;
+  width: 0px;
+  height: auto;
+  border-radius: 2px;
+  flex-shrink: 0;
+  user-select: none;
+  opacity: 0;
+  overflow: hidden;
+  transition: width 0.2s ease, opacity 0.2s ease;
+}
+
+.markerLabel:hover .flagImg {
+  width: 16px;
+  opacity: 1;
+}
+
+.flagName {
+  color: rgba(240, 192, 64, 0.95);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
 .markerLabel:hover {
-  transform: scale(1.3);
-  background: rgba(255, 255, 255, 0.96);
-  border-color: rgba(240, 192, 64, 0.7);
-  box-shadow: 0 2px 10px rgba(240, 192, 64, 0.35);
+  transform: scale(1.25);
+  background: rgba(10, 8, 0, 0.85);
+  border-color: rgba(240, 192, 64, 0.75);
+  box-shadow: 0 2px 12px rgba(240, 192, 64, 0.35);
   z-index: 10;
+}
+
+/* 좌측 하단 실시간 시계 위젯 */
+.clockWidget {
+  position: absolute;
+  bottom: 36px;
+  left: 40px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  pointer-events: none;
+  user-select: none;
+}
+
+.clockCity {
+  font-family: "Pretendard", monospace;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: rgba(240, 192, 64, 0.85);
+}
+
+.clockTime {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 32px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  color: rgba(255, 255, 255, 0.92);
+  line-height: 1;
+}
+
+.clockDate {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 11px;
+  letter-spacing: 1px;
+  color: rgba(255, 255, 255, 0.45);
+  margin-top: 2px;
+}
+
+.clockTz {
+  font-family: "Courier New", Courier, monospace;
+  font-size: 9px;
+  letter-spacing: 0.8px;
+  color: rgba(240, 192, 64, 0.4);
+  margin-top: 1px;
 }

--- a/FrontEnd/src/layouts/MainLayout.jsx
+++ b/FrontEnd/src/layouts/MainLayout.jsx
@@ -18,6 +18,7 @@ export default function MainLayout() {
     <div 
       className={classNames(styles.layout, {
         [styles['intro-page']]: isIntroPage,
+        [styles['landing-page']]: isLandingPage,
       })}
     >
       <Header />

--- a/FrontEnd/src/layouts/MainLayout.module.css
+++ b/FrontEnd/src/layouts/MainLayout.module.css
@@ -6,6 +6,11 @@
     padding-top: 60px;
   }
 
+  /* 랜딩: 고정 헤더가 지구본 위에 겹치므로 상단 패딩 제거 (흰 띠 방지) */
+  .layout.landing-page {
+    padding-top: 0;
+  }
+
   /* 소개 페이지에만 배경 이미지 설정 */
   .layout.intro-page {
     background-image: url('../assets/intro_background.png');

--- a/FrontEnd/src/pages/LandingPage.jsx
+++ b/FrontEnd/src/pages/LandingPage.jsx
@@ -1,10 +1,10 @@
-import GlobeComponent from '../components/globe/Globe';
+import GlobeComponent from "../components/globe/Globe";
+import styles from "./LandingPage.module.css";
 
 export default function LandingPage() {
-
-    return(
-        <div style={{width: "100vw", height: "85vh"}}>
-        <GlobeComponent />
-      </div>
-    )
+  return (
+    <div className={styles.wrap}>
+      <GlobeComponent />
+    </div>
+  );
 }

--- a/FrontEnd/src/pages/LandingPage.module.css
+++ b/FrontEnd/src/pages/LandingPage.module.css
@@ -1,79 +1,8 @@
-
-
-.landingPage--container{
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    height: 85vh;
-    width: 100%;
-}
-
-.landingPage--title{
-    font-size: 76px;
-    color: white;
-}
-
-.landingPage--searchContainer{
-    width: 80%;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: center;
-}
-
-.landingPage--searchInputContainer{
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    font-size: 17px;
-    width: 70%;
-    max-width: 40vw;;
-    height: 50px;
-    border: 1px solid rgb(228, 228, 228);
-    border-radius: 10px;
-    background-color: white;
-    padding-left: 20px;
-    margin-right: 2%;
-    overflow: hidden;
-}
-.input-icon{
-    color: rgb(0, 0, 0);
-    margin-right: 10px;
-}
-
-.landingPage--input{
-    font-size: 17px;
-    height: 40px;
-    width: 700px;
-    outline: none;
-    border: none;
-}
-
-.landingPage--input::placeholder {
-    font-size: 17px;
-    color: black;
-}
-.landingPage--input:focus {
-    outline: none;
-    border: none;
-}
-
-
-
-.landingPage--button{
-    font-size: 18px;
-    width: 100px;
-    height: 50px;
-    border: none;
-    border-radius: 12px;
-    background-color: white;
-    box-shadow: inset 0px 3px 5px rgb(172, 172, 172);
-}
-
-.landingPage--button:hover,
-.landingPage--button:focus{
-    background-color: rgb(226, 226, 226);
-    box-shadow: inset 0px 3px 5px rgb(142, 140, 148);
-    outline: none;
+.wrap {
+  width: 100%;
+  min-height: 100vh;
+  height: 100vh;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
 }


### PR DESCRIPTION
1. refactor: globe.gl → cobe 교체 및 마커 클릭 기능 구현
- 랜딩 지구본을 **globe.gl → cobe(WebGL)** 로 교체
- BE에서 트렌드를 제공하는 **26개 국가**만 마커로 표시, 클릭 시 트렌드 모달 연동
- CSS 앵커 포지셔닝 등으로 마커·라벨 위치 정합성 개선

2. style: 랜딩 뷰포트 및 헤더 반응형 설정 수정
- 랜딩: **풀뷰포트** 정리, 헤더와 본문 사이 **흰 띠** 완화 (`landing-page` 패딩 등)
- 헤더: **1100px 이하 햄버거**, 네비 **nowrap**·그리드 조정 등 반응형 보완

3. feat: 국기 라벨 및 지역별 실시간 시계 추가
- 지구본 마커: **국기 이미지(flagcdn) + 국가명**, 호버 시 국기 표시 등 UI
- 랜딩 **좌측 하단**에 브라우저 **로컬 타임존** 기준 실시간 시계 위젯

4. feat: 로고 툴팁 SVG 화살표·테두리 정리 및 헤더 그리드 정렬
- 로고 호버 툴팁: CSS 삼각형 제거 → **SVG**(열린 path로 꼭짓점 두 변만 stroke), 상단 테두리는 **좌·우 구간만** gradient로 분할
- 헤더: **`1fr auto 1fr` + `justify-self`** 로 메인 메뉴 중앙 정렬 복구
- **`TranslatedText`**: 첫 페인트부터 원문 표시로 빈 칸 최소화

### 체크리스트
- [ ] 로컬 확인 완료
- [ ] BE 연동 확인 완료

### 관련 이슈
Closes #73 