### PR TITLE
fix(globe): 트렌드 API 레이스로 인한 국가·데이터 불일치 방지

### DIFF
--- a/FrontEnd/src/api/landingPageAPI.js
+++ b/FrontEnd/src/api/landingPageAPI.js
@@ -1,13 +1,30 @@
 import axios from "axios";
 
-export async function getTrend(code) {
+function isAbortError(error) {
+  return (
+    error?.code === "ERR_CANCELED" ||
+    error?.name === "CanceledError" ||
+    error?.name === "AbortError"
+  );
+}
+
+/** @param {string} code 국가 코드
+ *  @param {{ signal?: AbortSignal }} [options] 연속 클릭 시 이전 요청 취소용 */
+export async function getTrend(code, options = {}) {
+  const { signal } = options;
   try {
     const baseUrl = `${import.meta.env.VITE_APP_API}/api/trend?code=${code}`;
-    const response = await axios.get(baseUrl);
+    const response = await axios.get(baseUrl, { signal });
     return response.data;
   } catch (error) {
+    if (isAbortError(error)) throw error;
     console.error("트렌드 데이터를 불러오는 데 실패했습니다:", error);
-    return [];
+    return {
+      isSuccess: false,
+      data: [],
+      timestamp: new Date().toISOString(),
+      message: "",
+    };
   }
 }
 

--- a/FrontEnd/src/components/globe/Globe.jsx
+++ b/FrontEnd/src/components/globe/Globe.jsx
@@ -9,52 +9,33 @@ const BASE_THETA = 0.3;
 
 // BE에서 실제 트렌드를 수집하는 26개 지원 국가
 const COUNTRY_MARKERS = {
-  KR: { lat: 35.9,  lng: 127.8,  name: "South Korea"    },
-  JP: { lat: 36.2,  lng: 138.3,  name: "Japan"          },
-  HK: { lat: 22.4,  lng: 114.1,  name: "Hong Kong"      },
-  TW: { lat: 23.7,  lng: 121.0,  name: "Taiwan"         },
-  SG: { lat: 1.4,   lng: 103.8,  name: "Singapore"      },
-  MY: { lat: 4.2,   lng: 108.0,  name: "Malaysia"       },
-  ID: { lat: -0.8,  lng: 113.9,  name: "Indonesia"      },
-  IN: { lat: 20.6,  lng: 79.1,   name: "India"          },
-  AU: { lat: -25.3, lng: 133.8,  name: "Australia"      },
-  US: { lat: 37.1,  lng: -95.7,  name: "United States"  },
-  CA: { lat: 56.1,  lng: -106.3, name: "Canada"         },
-  MX: { lat: 23.6,  lng: -102.6, name: "Mexico"         },
-  BR: { lat: -14.2, lng: -51.9,  name: "Brazil"         },
-  CO: { lat: 4.6,   lng: -74.1,  name: "Colombia"       },
-  GB: { lat: 55.4,  lng: -3.4,   name: "United Kingdom" },
-  FR: { lat: 46.2,  lng: 2.2,    name: "France"         },
-  DE: { lat: 51.2,  lng: 10.5,   name: "Germany"        },
-  IT: { lat: 41.9,  lng: 12.6,   name: "Italy"          },
-  ES: { lat: 40.5,  lng: -3.7,   name: "Spain"          },
-  NL: { lat: 52.1,  lng: 5.3,    name: "Netherlands"    },
-  AT: { lat: 47.5,  lng: 14.6,   name: "Austria"        },
-  DK: { lat: 56.3,  lng: 9.5,    name: "Denmark"        },
-  GR: { lat: 39.1,  lng: 21.8,   name: "Greece"         },
-  RU: { lat: 61.5,  lng: 105.3,  name: "Russia"         },
-  TR: { lat: 38.9,  lng: 35.2,   name: "Turkey"         },
-  EG: { lat: 26.8,  lng: 30.8,   name: "Egypt"          },
+  KR: { lat: 35.9, lng: 127.8, name: "South Korea" },
+  JP: { lat: 36.2, lng: 138.3, name: "Japan" },
+  HK: { lat: 22.4, lng: 114.1, name: "Hong Kong" },
+  TW: { lat: 23.7, lng: 121.0, name: "Taiwan" },
+  SG: { lat: 1.4, lng: 103.8, name: "Singapore" },
+  MY: { lat: 4.2, lng: 108.0, name: "Malaysia" },
+  ID: { lat: -0.8, lng: 113.9, name: "Indonesia" },
+  IN: { lat: 20.6, lng: 79.1, name: "India" },
+  AU: { lat: -25.3, lng: 133.8, name: "Australia" },
+  US: { lat: 37.1, lng: -95.7, name: "United States" },
+  CA: { lat: 56.1, lng: -106.3, name: "Canada" },
+  MX: { lat: 23.6, lng: -102.6, name: "Mexico" },
+  BR: { lat: -14.2, lng: -51.9, name: "Brazil" },
+  CO: { lat: 4.6, lng: -74.1, name: "Colombia" },
+  GB: { lat: 55.4, lng: -3.4, name: "United Kingdom" },
+  FR: { lat: 46.2, lng: 2.2, name: "France" },
+  DE: { lat: 51.2, lng: 10.5, name: "Germany" },
+  IT: { lat: 41.9, lng: 12.6, name: "Italy" },
+  ES: { lat: 40.5, lng: -3.7, name: "Spain" },
+  NL: { lat: 52.1, lng: 5.3, name: "Netherlands" },
+  AT: { lat: 47.5, lng: 14.6, name: "Austria" },
+  DK: { lat: 56.3, lng: 9.5, name: "Denmark" },
+  GR: { lat: 39.1, lng: 21.8, name: "Greece" },
+  RU: { lat: 61.5, lng: 105.3, name: "Russia" },
+  TR: { lat: 38.9, lng: 35.2, name: "Turkey" },
+  EG: { lat: 26.8, lng: 30.8, name: "Egypt" },
 };
-
-/**
- * 클릭/호버 감지 전용 투영 함수.
- * CSS 앵커 포지셔닝이 라벨 위치를 담당하므로 여기선 좌표 계산만 사용.
- */
-function projectMarker(lat, lng, phi, theta, canvasW, canvasH) {
-  const latR = (lat * Math.PI) / 180;
-  const lngR = (lng * Math.PI) / 180;
-  const x0 = Math.cos(latR) * Math.sin(lngR);
-  const y0 = Math.sin(latR);
-  const z0 = Math.cos(latR) * Math.cos(lngR);
-  const x1 = x0 * Math.cos(phi) + z0 * Math.sin(phi);
-  const z1 = -x0 * Math.sin(phi) + z0 * Math.cos(phi);
-  const y2 = y0 * Math.cos(theta) - z1 * Math.sin(theta);
-  const z2 = y0 * Math.sin(theta) + z1 * Math.cos(theta);
-  if (z2 < 0.05) return null;
-  const r = Math.min(canvasW, canvasH) / 2;
-  return { x: canvasW / 2 + x1 * r, y: canvasH / 2 - y2 * r, z: z2 };
-}
 
 const GlobeComponent = () => {
   const canvasRef = useRef(null);
@@ -250,10 +231,13 @@ const GlobeComponent = () => {
 
   useEffect(() => {
     if (!selectedCountry) return;
+    // 국가가 없다 : 마커 선택 x , 모달창을 닫은 경우 전부 포함 : 분기 해당
 
     const gen = ++trendFetchGenRef.current;
-    setTrendData(null);
-    const controller = new AbortController();
+    setTrendData(null); // 이전 요청 취소를 위해 데이터 초기화
+    // 선택된 국가가 변경되었는데도 Trend Data 는 아직 이전 요청의 결과일 수 있기 때문임.
+
+    const controller = new AbortController(); // 요청 취소를 위해 AbortController 생성
 
     getTrend(selectedCountry, { signal: controller.signal })
       .then((data) => {
@@ -262,6 +246,7 @@ const GlobeComponent = () => {
       })
       .catch((err) => {
         if (
+          // Optional Chaining 공부해보기
           err?.code === "ERR_CANCELED" ||
           err?.name === "CanceledError" ||
           err?.name === "AbortError"

--- a/FrontEnd/src/components/globe/Globe.jsx
+++ b/FrontEnd/src/components/globe/Globe.jsx
@@ -64,6 +64,8 @@ const GlobeComponent = () => {
   const thetaRef = useRef(BASE_THETA);
   const trendModalRef = useRef(null);
   const newsModalRef = useRef(null);
+  /** 연속 국가 클릭 시 마지막 요청만 반영 (레이스 방지) */
+  const trendFetchGenRef = useRef(0);
 
   const [selectedCountry, setSelectedCountry] = useState(null);
   const [trendData, setTrendData] = useState(null);
@@ -247,12 +249,35 @@ const GlobeComponent = () => {
   }, []);
 
   useEffect(() => {
-    if (selectedCountry) {
-      setTrendData(null);
-      getTrend(selectedCountry)
-        .then((data) => setTrendData(data))
-        .catch(() => setTrendData([]));
-    }
+    if (!selectedCountry) return;
+
+    const gen = ++trendFetchGenRef.current;
+    setTrendData(null);
+    const controller = new AbortController();
+
+    getTrend(selectedCountry, { signal: controller.signal })
+      .then((data) => {
+        if (gen !== trendFetchGenRef.current) return;
+        setTrendData(data);
+      })
+      .catch((err) => {
+        if (
+          err?.code === "ERR_CANCELED" ||
+          err?.name === "CanceledError" ||
+          err?.name === "AbortError"
+        ) {
+          return;
+        }
+        if (gen !== trendFetchGenRef.current) return;
+        setTrendData({
+          isSuccess: false,
+          data: [],
+          timestamp: new Date().toISOString(),
+          message: "",
+        });
+      });
+
+    return () => controller.abort();
   }, [selectedCountry]);
 
   return (


### PR DESCRIPTION
## 배경
Globe 에서 대상 국가를 빠르게 바꿀 때, 이전 요청이 나중에 도착하면 `trendData`만 덮어써서 모달 제목(`selectedCountry`)과 트렌드 목록이 일치하지 않는 가능성이 존재

## 흐름 정리 

Globe.jsx에서 마커 클릭 → selectedCountry 변경 → useEffect 실행 흐름

1. 앵커 포지셔닝
onClick={() => setSelectedCountry(code)} 을 통한 State 가 변경됨 

2.  이후 useEffect를 통한 검사 / 요청의 수행 
특정 props / state가 바뀌면 → 그걸 의존성에 넣어 둔 useEffect가 다시 실행되는 구조
( 옵셔널 체이닝 공부해보기 ) 

Abort Controller를 통해 1차적으로 방지하고 ( 요청 시점 이후 많은 요청이 얹어져서 실질적인 응답이 주어지는 국가와 다른 경우 )
-> 해당 Controller 는 런타임이 제공하는 내장 API 
gen 상수 : 트렌드 요청을 저장해서 요청과 응답 시점의 국가가 동일한지 더블 체크 

## 변경 사항
- `getTrend(code, { signal })`: axios에 `AbortSignal` 전달
- `Globe`: 국가 변경 시 진행 중 요청 `abort`, 요청 세대(ref)로 오래된 응답의 `setTrendData` 무시
- 실패 시 빈 배열 대신 `ApiResponse` 형태(`data`, `timestamp` 등)로 반환해 `TrendModal`과 일치

## 테스트
- [x] 지구본에서 국가를 연속으로 클릭했을 때 제목과 트렌드가 항상 같은 국가 기준인지 확인