### PR TITLE
[Feat/#77] cursor pagination 구현 및 기존 로직 전면 수정 

### DIFF
--- a/FrontEnd/src/api/getNewsCardAPI.js
+++ b/FrontEnd/src/api/getNewsCardAPI.js
@@ -1,5 +1,14 @@
 import axios from "axios";
 
+function formatArticleDates(article) {
+  const date = new Date(article.publishedAt);
+  return {
+    ...article,
+    year: date.getFullYear().toString(),
+    month: (date.getMonth() + 1).toString().padStart(2, "0"),
+    day: date.getDate().toString().padStart(2, "0"),
+  };
+}
 
 // mainPage - Hot News Card //
 // response.data.data.content[0].title
@@ -9,17 +18,7 @@ export async function getHot(page, size) {
         const response = await axios.get(baseUrl);
         
         if (response.data.isSuccess === true) {
-            // 날짜를 분리해서 새로운 객체 생성
-            const formattedResults = response.data.data.content.map(article => {
-                const date = new Date(article.publishedAt); // 문자열을 Date 객체로 변환
-                return {
-                    ...article,
-                    year: date.getFullYear().toString(),
-                    month: (date.getMonth() + 1).toString().padStart(2, '0'), // 두 자리로 맞춤
-                    day: date.getDate().toString().padStart(2, '0'), // 두 자리로 맞춤
-                };
-            });
-
+            const formattedResults = response.data.data.content.map(formatArticleDates);
             return formattedResults;
         }
         else {
@@ -33,32 +32,28 @@ export async function getHot(page, size) {
 }
 
 
-// mainPage - Latest News Card //
-export async function getLatest(page, size) {
+// mainPage - Latest News Card (cursor 기반 최신순, /api/articles/latest offset 대체)
+/** @returns {{ articles: object[], nextCursor: string|null, hasNext: boolean }} */
+export async function getLatestCursor(cursor, size) {
     try {
-        const baseUrl = `${import.meta.env.VITE_APP_API}/api/articles/latest?page=${page}&size=${size}`;
+        const params = new URLSearchParams({ size: String(size) });
+        if (cursor) params.set("cursor", cursor);
+        const baseUrl = `${import.meta.env.VITE_APP_API}/api/articles/cursor?${params}`;
         const response = await axios.get(baseUrl);
-        
-        if (response.data.isSuccess === true) {
-            // 날짜를 분리해서 새로운 객체 생성
-            const formattedResults = response.data.data.content.map(article => {
-                const date = new Date(article.publishedAt); // 문자열을 Date 객체로 변환
-                return {
-                    ...article,
-                    year: date.getFullYear().toString(),
-                    month: (date.getMonth() + 1).toString().padStart(2, '0'), // 두 자리로 맞춤
-                    day: date.getDate().toString().padStart(2, '0'), // 두 자리로 맞춤
-                };
-            });
 
-            return formattedResults;
+        if (response.data.isSuccess === true && response.data.data) {
+            const { articles, nextCursor, hasNext } = response.data.data;
+            const formattedResults = (articles || []).map(formatArticleDates);
+            return {
+                articles: formattedResults,
+                nextCursor: nextCursor ?? null,
+                hasNext: Boolean(hasNext),
+            };
         }
-        else {
-            return [];
-        }
+        return { articles: [], nextCursor: null, hasNext: false };
     } catch (error) {
         console.error("최근 뉴스 데이터를 불러오는 데 실패했습니다:", error);
-        return [];
+        return { articles: [], nextCursor: null, hasNext: false };
     }
 }
 

--- a/FrontEnd/src/components/mainPage/CursorPagination.jsx
+++ b/FrontEnd/src/components/mainPage/CursorPagination.jsx
@@ -1,0 +1,70 @@
+import styled from "./Pagenation.module.css";
+import PropTypes from "prop-types";
+
+/**
+ * offset totalPages 없이 cursor 이전/다음만 지원 (임의 페이지 점프 없음).
+ * 인기 뉴스 Pagenation과 동일하게 버튼 자리를 유지하고, 불가 시 disabled 처리.
+ */
+function CursorPagination({
+  currentPageLabel,
+  canGoPrev,
+  canGoNext,
+  onFirst,
+  onPrev,
+  onNext,
+}) {
+  return (
+    <div className={styled.pagenationContainer}>
+      <button
+        type="button"
+        className={styled.pagenationButton}
+        onClick={onFirst}
+        disabled={!canGoPrev}
+        aria-label="첫 페이지"
+        title="첫 페이지"
+      >
+        ≪
+      </button>
+      <button
+        type="button"
+        className={styled.pagenationButton}
+        onClick={onPrev}
+        disabled={!canGoPrev}
+        aria-label="이전 페이지"
+        title="이전 페이지"
+      >
+        &lt;
+      </button>
+      <div
+        className={styled.cursorPageIndicator}
+        aria-current="page"
+        role="status"
+      >
+        <span className={styled.cursorPagePrefix}>페이지</span>
+        <span className={styled.cursorPageNumber}>{currentPageLabel}</span>
+      </div>
+      <button
+        type="button"
+        className={styled.pagenationButton}
+        onClick={onNext}
+        disabled={!canGoNext}
+        aria-label="다음 페이지"
+        title="다음 페이지"
+      >
+        &gt;
+      </button>
+    </div>
+  );
+}
+
+CursorPagination.propTypes = {
+  currentPageLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
+  canGoPrev: PropTypes.bool.isRequired,
+  canGoNext: PropTypes.bool.isRequired,
+  onFirst: PropTypes.func.isRequired,
+  onPrev: PropTypes.func.isRequired,
+  onNext: PropTypes.func.isRequired,
+};
+
+export default CursorPagination;

--- a/FrontEnd/src/components/mainPage/CursorPagination.jsx
+++ b/FrontEnd/src/components/mainPage/CursorPagination.jsx
@@ -53,6 +53,16 @@ function CursorPagination({
       >
         &gt;
       </button>
+      <button
+        type="button"
+        className={styled.pagenationButton}
+        disabled
+        aria-label="마지막 페이지"
+        title="마지막 페이지로 바로 이동할 수 없습니다_cursor 기반"
+        tabIndex={-1}
+      >
+        ≫
+      </button>
     </div>
   );
 }

--- a/FrontEnd/src/components/mainPage/MainNews.jsx
+++ b/FrontEnd/src/components/mainPage/MainNews.jsx
@@ -2,21 +2,28 @@ import styled from './News.module.css';
 import HotNewsCard from '../newsCard/HotNewsCard';
 import BasicNewsCard from '../newsCard/BasicNewsCard';
 import Pagenation from './Pagenation';
-import { useState, useEffect } from 'react';
+import CursorPagination from './CursorPagination';
+import { useState, useEffect, useCallback } from 'react';
 
 //번역 컴포넌트
 import TranslatedText from '../../api/TranslatedText';
 
-import { getHot, getLatest } from '../../api/getNewsCardAPI';
+import { getHot, getLatestCursor } from '../../api/getNewsCardAPI';
+
+const LATEST_PAGE_SIZE = 8;
 
 export default function MainNews(){
     const [hotNews, setHotNews] = useState([]);
     const [basicNews, setBasicNews] = useState([]);
     const [hotPage, setHotPage] = useState(1);
-    const [basicPage, setBasicPage] = useState(1);
     const hotTotalPages = 7;
-    const basicTotalPages = 10;
 
+    const [latestNextCursor, setLatestNextCursor] = useState(null);
+    const [latestHasNext, setLatestHasNext] = useState(false);
+    /** 현재 목록을 불러올 때 API에 넘긴 cursor (첫 페이지는 null) */
+    const [latestRequestCursor, setLatestRequestCursor] = useState(null);
+    /** 다음으로 갈 때 push(latestRequestCursor) — 이전으로 갈 때 pop 한 값으로 재요청 */
+    const [latestStack, setLatestStack] = useState([]);
 
     useEffect(() => {
         async function fetchHotNews() {
@@ -31,19 +38,46 @@ export default function MainNews(){
         fetchHotNews();
     }, [hotPage]);
 
+    const applyLatestResponse = useCallback((res) => {
+        setBasicNews(res.articles);
+        setLatestNextCursor(res.nextCursor);
+        setLatestHasNext(res.hasNext);
+    }, []);
+
+    const loadLatestFirst = useCallback(async () => {
+        const res = await getLatestCursor(null, LATEST_PAGE_SIZE);
+        applyLatestResponse(res);
+        setLatestRequestCursor(null);
+        setLatestStack([]);
+    }, [applyLatestResponse]);
 
     useEffect(() => {
-        async function fetchBasicNews() {
-            const data = await getLatest(basicPage - 1, 8);
-            
-            if (data && typeof data === "object") {
-                setBasicNews(Object.values(data));  
-            } else {
-                console.error("🚨 예상과 다른 데이터 구조:", data);
-            }
-        }
-        fetchBasicNews();
-    }, [basicPage]);
+        loadLatestFirst();
+    }, [loadLatestFirst]);
+
+    const handleLatestNext = useCallback(async () => {
+        if (!latestHasNext || latestNextCursor == null) return;
+        setLatestStack((s) => [...s, latestRequestCursor]);
+        const res = await getLatestCursor(latestNextCursor, LATEST_PAGE_SIZE);
+        applyLatestResponse(res);
+        setLatestRequestCursor(latestNextCursor);
+    }, [latestHasNext, latestNextCursor, latestRequestCursor, applyLatestResponse]);
+
+    const handleLatestPrev = useCallback(async () => {
+        if (latestStack.length === 0) return;
+        const parentCursor = latestStack[latestStack.length - 1];
+        setLatestStack((s) => s.slice(0, -1));
+        const res = await getLatestCursor(parentCursor, LATEST_PAGE_SIZE);
+        applyLatestResponse(res);
+        setLatestRequestCursor(parentCursor);
+    }, [latestStack, applyLatestResponse]);
+
+    const handleLatestFirst = useCallback(async () => {
+        await loadLatestFirst();
+    }, [loadLatestFirst]);
+
+    const latestPageLabel = latestStack.length + 1;
+    const canLatestPrev = latestStack.length > 0;
 
     return(
         <div className={styled['MainNews--container']}>
@@ -79,20 +113,20 @@ export default function MainNews(){
                 </div>
 
                 <div className={styled['MainNews--pages']}>
-                        <Pagenation
-                            currentPage={basicPage}
-                            totalPages={basicTotalPages}
-                            onPageChange={setBasicPage}
+                        <CursorPagination
+                            currentPageLabel={latestPageLabel}
+                            canGoPrev={canLatestPrev}
+                            canGoNext={latestHasNext}
+                            onFirst={handleLatestFirst}
+                            onPrev={handleLatestPrev}
+                            onNext={handleLatestNext}
                         />
                 </div>
             </div>
-            
-            
             
 
         </div>
     )
 }
-
 
 

--- a/FrontEnd/src/components/mainPage/MainNews.jsx
+++ b/FrontEnd/src/components/mainPage/MainNews.jsx
@@ -1,132 +1,163 @@
-import styled from './News.module.css';
-import HotNewsCard from '../newsCard/HotNewsCard';
-import BasicNewsCard from '../newsCard/BasicNewsCard';
-import Pagenation from './Pagenation';
-import CursorPagination from './CursorPagination';
-import { useState, useEffect, useCallback } from 'react';
+import styled from "./News.module.css";
+import HotNewsCard from "../newsCard/HotNewsCard";
+import BasicNewsCard from "../newsCard/BasicNewsCard";
+import Pagenation from "./Pagenation";
+import CursorPagination from "./CursorPagination";
+import { useState, useEffect, useCallback } from "react";
 
 //번역 컴포넌트
-import TranslatedText from '../../api/TranslatedText';
+import TranslatedText from "../../api/TranslatedText";
 
-import { getHot, getLatestCursor } from '../../api/getNewsCardAPI';
+import { getHot, getLatestCursor } from "../../api/getNewsCardAPI";
 
 const LATEST_PAGE_SIZE = 8;
 
-export default function MainNews(){
-    const [hotNews, setHotNews] = useState([]);
-    const [basicNews, setBasicNews] = useState([]);
-    const [hotPage, setHotPage] = useState(1);
-    const hotTotalPages = 7;
+export default function MainNews() {
+  const [hotNews, setHotNews] = useState([]);
+  const [basicNews, setBasicNews] = useState([]);
+  const [hotPage, setHotPage] = useState(1);
+  const hotTotalPages = 7;
 
-    const [latestNextCursor, setLatestNextCursor] = useState(null);
-    const [latestHasNext, setLatestHasNext] = useState(false);
-    /** 현재 목록을 불러올 때 API에 넘긴 cursor (첫 페이지는 null) */
-    const [latestRequestCursor, setLatestRequestCursor] = useState(null);
-    /** 다음으로 갈 때 push(latestRequestCursor) — 이전으로 갈 때 pop 한 값으로 재요청 */
-    const [latestStack, setLatestStack] = useState([]);
+  const [latestNextCursor, setLatestNextCursor] = useState(null);
+  const [latestHasNext, setLatestHasNext] = useState(false);
+  /** 현재 목록을 불러올 때 API에 넘긴 cursor (첫 페이지는 null) */
+  const [latestRequestCursor, setLatestRequestCursor] = useState(null);
+  /** 다음으로 갈 때 push(latestRequestCursor) — 이전으로 갈 때 pop 한 값으로 재요청 */
+  const [latestStack, setLatestStack] = useState([]);
 
-    useEffect(() => {
-        async function fetchHotNews() {
-            const data = await getHot(hotPage - 1, 6);
-            
-            if (data && typeof data === "object") {
-                setHotNews(Object.values(data));  
-            } else {
-                console.error("🚨 예상과 다른 데이터 구조:", data);
-            }
-        }
-        fetchHotNews();
-    }, [hotPage]);
+  useEffect(() => {
+    async function fetchHotNews() {
+      const data = await getHot(hotPage - 1, 6);
 
-    const applyLatestResponse = useCallback((res) => {
-        setBasicNews(res.articles);
-        setLatestNextCursor(res.nextCursor);
-        setLatestHasNext(res.hasNext);
-    }, []);
+      if (data && typeof data === "object") {
+        setHotNews(Object.values(data));
+      } else {
+        console.error("🚨 예상과 다른 데이터 구조:", data);
+      }
+    }
+    fetchHotNews();
+  }, [hotPage]);
 
-    const loadLatestFirst = useCallback(async () => {
-        const res = await getLatestCursor(null, LATEST_PAGE_SIZE);
-        applyLatestResponse(res);
-        setLatestRequestCursor(null);
-        setLatestStack([]);
-    }, [applyLatestResponse]);
+  const applyLatestResponse = useCallback((res) => {
+    setBasicNews(res.articles);
+    setLatestNextCursor(res.nextCursor);
+    setLatestHasNext(res.hasNext);
+  }, []);
 
-    useEffect(() => {
-        loadLatestFirst();
-    }, [loadLatestFirst]);
+  const loadLatestFirst = useCallback(async () => {
+    const res = await getLatestCursor(null, LATEST_PAGE_SIZE);
+    applyLatestResponse(res);
+    setLatestRequestCursor(null);
+    setLatestStack([]);
+  }, [applyLatestResponse]);
 
-    const handleLatestNext = useCallback(async () => {
-        if (!latestHasNext || latestNextCursor == null) return;
-        setLatestStack((s) => [...s, latestRequestCursor]);
-        const res = await getLatestCursor(latestNextCursor, LATEST_PAGE_SIZE);
-        applyLatestResponse(res);
-        setLatestRequestCursor(latestNextCursor);
-    }, [latestHasNext, latestNextCursor, latestRequestCursor, applyLatestResponse]);
+  useEffect(() => {
+    loadLatestFirst();
+  }, [loadLatestFirst]);
 
-    const handleLatestPrev = useCallback(async () => {
-        if (latestStack.length === 0) return;
-        const parentCursor = latestStack[latestStack.length - 1];
-        setLatestStack((s) => s.slice(0, -1));
-        const res = await getLatestCursor(parentCursor, LATEST_PAGE_SIZE);
-        applyLatestResponse(res);
-        setLatestRequestCursor(parentCursor);
-    }, [latestStack, applyLatestResponse]);
+  const handleLatestNext = useCallback(async () => {
+    if (!latestHasNext || latestNextCursor == null) return;
+    setLatestStack((s) => [...s, latestRequestCursor]);
+    const res = await getLatestCursor(latestNextCursor, LATEST_PAGE_SIZE);
+    applyLatestResponse(res);
+    setLatestRequestCursor(latestNextCursor);
+  }, [
+    latestHasNext,
+    latestNextCursor,
+    latestRequestCursor,
+    applyLatestResponse,
+  ]);
 
-    const handleLatestFirst = useCallback(async () => {
-        await loadLatestFirst();
-    }, [loadLatestFirst]);
+  const handleLatestPrev = useCallback(async () => {
+    if (latestStack.length === 0) return;
+    const parentCursor = latestStack[latestStack.length - 1];
+    setLatestStack((s) => s.slice(0, -1));
+    const res = await getLatestCursor(parentCursor, LATEST_PAGE_SIZE);
+    applyLatestResponse(res);
+    setLatestRequestCursor(parentCursor);
+  }, [latestStack, applyLatestResponse]);
 
-    const latestPageLabel = latestStack.length + 1;
-    const canLatestPrev = latestStack.length > 0;
+  const handleLatestFirst = useCallback(async () => {
+    await loadLatestFirst();
+  }, [loadLatestFirst]);
 
-    return(
-        <div className={styled['MainNews--container']}>
-            <div className={styled['MainNews--Newscontainer']}>
-                <div className={styled['MainNews--titleContainer']}>
-                    <h1 className={styled['MainNews--title']}><TranslatedText text="Popular News"/></h1>
-                </div>
+  const latestPageLabel = latestStack.length + 1;
+  const canLatestPrev = latestStack.length > 0;
 
-                <div className={styled['MainNews--News']}>
-                    {hotNews.map((news) => (
-                        <HotNewsCard key={news.id} id={news.id} press={news.sourceName}  title={news.title} summary={news.description} image={news.urlToImage} year={news.year} month={news.month} day={news.day} />
-                    ))}
-                </div>
-                
-                <div className={styled['MainNews--pages']}>
-                        <Pagenation
-                            currentPage={hotPage}
-                            totalPages={hotTotalPages}
-                            onPageChange={setHotPage}
-                        />
-                </div>
-            </div>
-
-            <div className={styled['MainNews--Newscontainer']}>
-                <div className={styled['MainNews--titleContainer']}>
-                    <h1 className={styled['MainNews--title']}><TranslatedText text="Latest News"/></h1>
-                </div>
-
-                <div className={styled['MainNews--News__latest']}>
-                    {basicNews.map((news) => (
-                        <BasicNewsCard key={news.id} id={news.id} press={news.sourceName}  title={news.title} summary={news.description} image={news.urlToImage} year={news.year} month={news.month} day={news.day} />
-                    ))}
-                </div>
-
-                <div className={styled['MainNews--pages']}>
-                        <CursorPagination
-                            currentPageLabel={latestPageLabel}
-                            canGoPrev={canLatestPrev}
-                            canGoNext={latestHasNext}
-                            onFirst={handleLatestFirst}
-                            onPrev={handleLatestPrev}
-                            onNext={handleLatestNext}
-                        />
-                </div>
-            </div>
-            
-
+  return (
+    <div className={styled["MainNews--container"]}>
+      <div className={styled["MainNews--Newscontainer"]}>
+        <div className={styled["MainNews--titleBlock"]}>
+          <h1 className={styled["MainNews--title"]}>
+            <TranslatedText text="Popular News" />
+          </h1>
+          <p className={styled["MainNews--subtitle"]}>
+            <TranslatedText text="최근 조회수 기준 정렬입니다." />
+          </p>
         </div>
-    )
+
+        <div className={styled["MainNews--News"]}>
+          {hotNews.map((news) => (
+            <HotNewsCard
+              key={news.id}
+              id={news.id}
+              press={news.sourceName}
+              title={news.title}
+              summary={news.description}
+              image={news.urlToImage}
+              year={news.year}
+              month={news.month}
+              day={news.day}
+            />
+          ))}
+        </div>
+
+        <div className={styled["MainNews--pages"]}>
+          <Pagenation
+            currentPage={hotPage}
+            totalPages={hotTotalPages}
+            onPageChange={setHotPage}
+          />
+        </div>
+      </div>
+
+      <div className={styled["MainNews--Newscontainer"]}>
+        <div className={styled["MainNews--titleBlock"]}>
+          <h1 className={styled["MainNews--title"]}>
+            <TranslatedText text="Latest News" />
+          </h1>
+          <p className={styled["MainNews--subtitle"]}>
+            <TranslatedText text="발행일 기준 최신순 정렬입니다." />
+          </p>
+        </div>
+
+        <div className={styled["MainNews--News__latest"]}>
+          {basicNews.map((news) => (
+            <BasicNewsCard
+              key={news.id}
+              id={news.id}
+              press={news.sourceName}
+              title={news.title}
+              summary={news.description}
+              image={news.urlToImage}
+              year={news.year}
+              month={news.month}
+              day={news.day}
+            />
+          ))}
+        </div>
+
+        <div className={styled["MainNews--pages"]}>
+          <CursorPagination
+            currentPageLabel={latestPageLabel}
+            canGoPrev={canLatestPrev}
+            canGoNext={latestHasNext}
+            onFirst={handleLatestFirst}
+            onPrev={handleLatestPrev}
+            onNext={handleLatestNext}
+          />
+        </div>
+      </div>
+    </div>
+  );
 }
-
-

--- a/FrontEnd/src/components/mainPage/News.module.css
+++ b/FrontEnd/src/components/mainPage/News.module.css
@@ -34,9 +34,23 @@
     margin-bottom: 20px;
 }
 
+.MainNews--titleBlock {
+    width: 100%;
+    margin-bottom: 20px;
+}
+
 .MainNews--title{
     font-size: clamp(18px, 2vw, 28px);
-    margin:0;
+    margin: 0 0 6px 0;
+}
+
+.MainNews--subtitle {
+    margin: 0;
+    font-size: clamp(12px, 1.35vw, 14px);
+    font-weight: 500;
+    color: #6b6b6b;
+    line-height: 1.5;
+    letter-spacing: -0.01em;
 }
 
 .MainNews--News {

--- a/FrontEnd/src/components/mainPage/Pagenation.jsx
+++ b/FrontEnd/src/components/mainPage/Pagenation.jsx
@@ -63,64 +63,72 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
   }
 
 
+  const canPrev = currentPage > 1;
+  const canNext = currentPage < totalPages;
+
   return (
-    <div className={styled['pagenationContainer']}>
-
-  {/* ≪ 처음 페이지 */}
-  {currentPage > 1 && (
-    <button
-      className={styled.pagenationButton}
-      onClick={firstClick}
-    >
-      ≪
-    </button>
-  )}
-
-  {/* < 이전 페이지 */}
-  {currentPage > 1 && (
-    <button
-      className={styled.pagenationButton}
-      onClick={prevClick}
-    >
-      &lt;
-    </button>
-  )}
-
-  {/* 페이지 번호 및 ... */}
-  {getPageNumbers().map((pageNumber, index) =>
-    pageNumber === '...' ? (
-      <span key={`ellipsis-${index}`} className={styled.ellipsis}>...</span>
-    ) : (
+    <div className={styled.pagenationContainer}>
       <button
-        key={pageNumber}
-        className={`${styled.pagenationButton} ${pageNumber === currentPage ? styled.activePage : ''}`}
-        onClick={() => onPageChange(pageNumber)}
+        type="button"
+        className={styled.pagenationButton}
+        onClick={firstClick}
+        disabled={!canPrev}
+        aria-label="첫 페이지"
+        title="첫 페이지"
       >
-        {pageNumber}
+        ≪
       </button>
-    )
-  )}
+      <button
+        type="button"
+        className={styled.pagenationButton}
+        onClick={prevClick}
+        disabled={!canPrev}
+        aria-label="이전 페이지"
+        title="이전 페이지"
+      >
+        &lt;
+      </button>
 
-  {/* > 다음 페이지 */}
-  {currentPage < totalPages && (
-    <button
-      className={styled.pagenationButton}
-      onClick={nextClick}
-    >
-      &gt;
-    </button>
-  )}
+      {getPageNumbers().map((pageNumber, index) =>
+        pageNumber === '...' ? (
+          <span key={`ellipsis-${index}`} className={styled.ellipsis}>
+            ...
+          </span>
+        ) : (
+          <button
+            type="button"
+            key={pageNumber}
+            className={`${styled.pagenationButton} ${pageNumber === currentPage ? styled.activePage : ''}`}
+            onClick={() => onPageChange(pageNumber)}
+            aria-label={`페이지 ${pageNumber}`}
+            aria-current={pageNumber === currentPage ? 'page' : undefined}
+          >
+            {pageNumber}
+          </button>
+        )
+      )}
 
-  {/* ≫ 마지막 페이지 */}
-  {currentPage < totalPages && (
-    <button
-      className={styled.pagenationButton}
-      onClick={lastClick}
-    >
-      ≫
-    </button>
-  )}
-</div>
+      <button
+        type="button"
+        className={styled.pagenationButton}
+        onClick={nextClick}
+        disabled={!canNext}
+        aria-label="다음 페이지"
+        title="다음 페이지"
+      >
+        &gt;
+      </button>
+      <button
+        type="button"
+        className={styled.pagenationButton}
+        onClick={lastClick}
+        disabled={!canNext}
+        aria-label="마지막 페이지"
+        title="마지막 페이지"
+      >
+        ≫
+      </button>
+    </div>
   );
 }
 

--- a/FrontEnd/src/components/mainPage/Pagenation.module.css
+++ b/FrontEnd/src/components/mainPage/Pagenation.module.css
@@ -50,3 +50,38 @@
   font-size: 16px;
   color: #aaa;
 }
+
+/* 커서 페이지네이션: 버튼 항상 자리 유지 + 비활성 */
+.pagenationButton:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+.pagenationButton:disabled:hover {
+  background-color: white;
+}
+
+.cursorPageIndicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 8px;
+  padding: 6px 14px;
+  border-radius: 4px;
+  background-color: rgb(255, 191, 53);
+  color: white;
+  font-size: 12px;
+  font-weight: 700;
+  min-width: 5.5rem;
+  justify-content: center;
+}
+
+.cursorPagePrefix {
+  font-weight: 600;
+  opacity: 0.95;
+}
+
+.cursorPageNumber {
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}

--- a/FrontEnd/src/components/mainPage/Pagenation.module.css
+++ b/FrontEnd/src/components/mainPage/Pagenation.module.css
@@ -1,11 +1,14 @@
 .pagenationContainer {
   width: 100%;
   display: flex;
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
   margin-top: 4vh;
   gap: 0.1rem;
   position: relative;
+  min-height: 44px;
+  row-gap: 6px;
 }
 
 .pagenationButton {

--- a/FrontEnd/src/components/mainPage/SearchContainer.module.css
+++ b/FrontEnd/src/components/mainPage/SearchContainer.module.css
@@ -9,13 +9,16 @@
 }
 
 .searchContainer--searchBar{
-    width: 60vw;
-    height: 6vh;
+    width: 100%;
+    max-width: min(720px, calc(100vw - 32px));
+    min-height: 48px;
+    height: auto;
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    align-items: stretch;
+    gap: 12px;
     margin-bottom: 20px;
-    
+    box-sizing: border-box;
 }
 
 .searchContainer--searchInputContainer{
@@ -23,13 +26,13 @@
     flex-direction: row;
     align-items: center;
     background-color: white;
-    width: 88%;
-    height: 100%;
+    flex: 1 1 0%;
+    min-width: 0;
+    min-height: 48px;
     padding: 0px 15px;
     border: 2px solid #565656;
     border-radius: 11px;
     box-shadow: 3px 3px 5px #a7a7a7;
-    margin-right: 20px;
     transition: border-color 0.25s ease, box-shadow 0.25s ease;
 }
 
@@ -65,10 +68,11 @@
 
 .searchContainer--Input{
     padding-left: 10px;
-    font-size: 18px;
+    font-size: clamp(14px, 2.5vw, 18px);
     border: none;
     outline: none;
     width: 100%;
+    min-width: 0;
     height: 80%;
     background: transparent;
     position: relative;
@@ -78,6 +82,7 @@
 .animated-placeholder {
     position: absolute;
     left: 10px;
+    right: 4px;
     top: 50%;
     transform: translateY(-50%);
     display: flex;
@@ -87,6 +92,8 @@
     user-select: none;
     white-space: nowrap;
     z-index: 0;
+    overflow: hidden;
+    min-width: 0;
 }
 
 .placeholder-text {
@@ -147,10 +154,12 @@
 }
 
 .searchContainer--searchButton{
-    font-size: 0.8vw;
+    font-size: clamp(12px, 1.8vw, 15px);
     font-weight: bold;
-    width: 9%;
-    height: 100%;
+    flex: 0 0 auto;
+    min-width: 5.75rem;
+    padding: 0 14px;
+    align-self: stretch;
     color: white;
     background-color: rgb(44, 44, 44);
     border: none;
@@ -162,6 +171,7 @@
     align-items: center;
     justify-content: center;
     gap: 5px;
+    white-space: nowrap;
 }
 
 .searchContainer--searchButton:hover {


### PR DESCRIPTION
### 최신 뉴스 · 커서 페이징

- `GET /api/articles/latest`(offset) 대신 **`GET /api/articles/cursor`** 사용 (`getLatestCursor`).
- `MainNews`: 커서 스택 기반 이전/다음·첫 페이지, `nextCursor` / `hasNext` 반영.
- `CursorPagination` 신규: 인기 뉴스와 동일한 **≪ / 이전 / (페이지 표시) / 다음 / ≫** 패턴(커서 특성상 **≫** 비활성).


### 인기 뉴스
- 기존 **`/api/articles/popular`** + 번호 페이지네이션 유지.
- `Pagenation`: 화살표·번호 버튼 **항상 표시**, 불가 시 `disabled` 처리해 최신 쪽과 톤 통일.
### 메인 섹션 카피 · 스타일
- 인기 / 최신 제목 아래 **부제** 추가 (예: 최근 조회수 기준 순위, 발행일 기준 최신순).
- `News.module.css`: `.MainNews--titleBlock`, `.MainNews--subtitle`.
### 검색창 반응형 (`SearchContainer`)
- 검색줄: `max-width` + `flex` + `gap`, 입력 **`flex: 1; min-width: 0`**, 검색 버튼 **`flex-shrink: 0` + `min-width`** 로 좁은 화면에서 버튼·입력 비율 깨짐 완화.
- 입력 글자 크기 `clamp`, 플레이스홀더 영역 overflow 완화.
### 기타 (동일 브랜치에 포함 시)

## How to test

- [x] 메인: **최신 뉴스** 이전·다음·첫 페이지, 네트워크에 `.../api/articles/cursor?size=8` 및 `cursor` 쿼리 확인.
- [x] 메인: **인기 뉴스** 페이지 이동, 버튼 disabled 동작.
- [x] 검색 페이지: 브라우저 가로 폭을 줄여도 **검색 버튼**이 세로로 찌그러지지 않는지 확인.

## Related
Closes #77 