### PR TITLE
[FEAT#79] 메인 탐색(Explore) — /api/articles/explore 연동

### DIFF
--- a/FrontEnd/src/api/getNewsCardAPI.js
+++ b/FrontEnd/src/api/getNewsCardAPI.js
@@ -57,6 +57,39 @@ export async function getLatestCursor(cursor, size) {
     }
 }
 
+/** 국가·카테고리·날짜 필터 + 커서 (/api/articles/explore). 키워드 검색과는 별개 API. */
+export async function getExploreArticles({
+  country,
+  category,
+  date,
+  cursor,
+  size = 12,
+}) {
+  try {
+    const params = new URLSearchParams({ size: String(size) });
+    if (country) params.set("country", country);
+    if (category) params.set("category", category);
+    if (date) params.set("date", date);
+    if (cursor) params.set("cursor", cursor);
+    const baseUrl = `${import.meta.env.VITE_APP_API}/api/articles/explore?${params}`;
+    const response = await axios.get(baseUrl);
+
+    if (response.data.isSuccess === true && response.data.data) {
+      const { articles, nextCursor, hasNext } = response.data.data;
+      const formattedResults = (articles || []).map(formatArticleDates);
+      return {
+        articles: formattedResults,
+        nextCursor: nextCursor ?? null,
+        hasNext: Boolean(hasNext),
+      };
+    }
+    return { articles: [], nextCursor: null, hasNext: false };
+  } catch (error) {
+    console.error("탐색 기사를 불러오는 데 실패했습니다:", error);
+    return { articles: [], nextCursor: null, hasNext: false };
+  }
+}
+
 
 // mainPage - Search News Card //
 // response.data.data.originalText

--- a/FrontEnd/src/components/mainPage/CursorPagination.jsx
+++ b/FrontEnd/src/components/mainPage/CursorPagination.jsx
@@ -1,5 +1,17 @@
 import styled from "./Pagenation.module.css";
 import PropTypes from "prop-types";
+import { useState, useEffect } from "react";
+import { useLanguage } from "../../util/LanguageContext.jsx";
+import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
+
+const CURSOR_PAGINATION_KO = {
+  first: "첫 페이지",
+  prev: "이전 페이지",
+  pagePrefix: "페이지",
+  next: "다음 페이지",
+  last: "마지막 페이지",
+  lastTitle: "마지막 페이지로 바로 이동할 수 없습니다 (커서 기반)",
+};
 
 /**
  * offset totalPages 없이 cursor 이전/다음만 지원 (임의 페이지 점프 없음).
@@ -13,6 +25,28 @@ function CursorPagination({
   onPrev,
   onNext,
 }) {
+  const { language } = useLanguage();
+  const [ui, setUi] = useState(() => ({ ...CURSOR_PAGINATION_KO }));
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const entries = Object.entries(CURSOR_PAGINATION_KO);
+      const translated = await Promise.all(
+        entries.map(([, ko]) => fetchTranslatedText(ko, language)),
+      );
+      if (cancelled) return;
+      const next = {};
+      entries.forEach(([key], i) => {
+        next[key] = translated[i];
+      });
+      setUi(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [language]);
+
   return (
     <div className={styled.pagenationContainer}>
       <button
@@ -20,8 +54,8 @@ function CursorPagination({
         className={styled.pagenationButton}
         onClick={onFirst}
         disabled={!canGoPrev}
-        aria-label="첫 페이지"
-        title="첫 페이지"
+        aria-label={ui.first}
+        title={ui.first}
       >
         ≪
       </button>
@@ -30,8 +64,8 @@ function CursorPagination({
         className={styled.pagenationButton}
         onClick={onPrev}
         disabled={!canGoPrev}
-        aria-label="이전 페이지"
-        title="이전 페이지"
+        aria-label={ui.prev}
+        title={ui.prev}
       >
         &lt;
       </button>
@@ -40,7 +74,7 @@ function CursorPagination({
         aria-current="page"
         role="status"
       >
-        <span className={styled.cursorPagePrefix}>페이지</span>
+        <span className={styled.cursorPagePrefix}>{ui.pagePrefix}</span>
         <span className={styled.cursorPageNumber}>{currentPageLabel}</span>
       </div>
       <button
@@ -48,8 +82,8 @@ function CursorPagination({
         className={styled.pagenationButton}
         onClick={onNext}
         disabled={!canGoNext}
-        aria-label="다음 페이지"
-        title="다음 페이지"
+        aria-label={ui.next}
+        title={ui.next}
       >
         &gt;
       </button>
@@ -57,8 +91,8 @@ function CursorPagination({
         type="button"
         className={styled.pagenationButton}
         disabled
-        aria-label="마지막 페이지"
-        title="마지막 페이지로 바로 이동할 수 없습니다_cursor 기반"
+        aria-label={ui.last}
+        title={ui.lastTitle}
         tabIndex={-1}
       >
         ≫

--- a/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
+++ b/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
@@ -1,0 +1,92 @@
+import styled from "./News.module.css";
+import BasicNewsCard from "../newsCard/BasicNewsCard";
+import CursorPagination from "./CursorPagination";
+import TranslatedText from "../../api/TranslatedText";
+import PropTypes from "prop-types";
+
+export default function ExploreResultsSection({
+  loading,
+  articles,
+  pageLabel,
+  canPrev,
+  hasNext,
+  onFirst,
+  onPrev,
+  onNext,
+  onDismiss,
+}) {
+  return (
+    <section className={styled["ExploreSection"]} aria-label="탐색 결과">
+      <div className={styled["ExploreSection__head"]}>
+        <div className={styled["ExploreSection__titles"]}>
+          <h2 className={styled["ExploreSection__title"]}>
+            <TranslatedText text="탐색 결과" />
+          </h2>
+          <p className={styled["ExploreSection__subtitle"]}>
+            <TranslatedText text="국가·카테고리·날짜 조건으로 모은 기사입니다. 키워드는 상단 검색으로 이용해 주세요." />
+          </p>
+        </div>
+        {onDismiss && (
+          <button
+            type="button"
+            className={styled["ExploreSection__dismiss"]}
+            onClick={onDismiss}
+          >
+            <TranslatedText text="닫기" />
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <p className={styled["ExploreSection__loading"]}>
+          <TranslatedText text="불러오는 중…" />
+        </p>
+      ) : articles.length === 0 ? (
+        <p className={styled["ExploreSection__empty"]}>
+          <TranslatedText text="조건에 맞는 기사가 없습니다." />
+        </p>
+      ) : (
+        <>
+          <div className={styled["ExploreSection__grid"]}>
+            {articles.map((news) => (
+              <BasicNewsCard
+                key={news.id}
+                id={news.id}
+                press={news.sourceName}
+                title={news.title}
+                summary={news.description}
+                image={news.urlToImage}
+                year={news.year}
+                month={news.month}
+                day={news.day}
+              />
+            ))}
+          </div>
+          <div className={styled["ExploreSection__pages"]}>
+            <CursorPagination
+              currentPageLabel={pageLabel}
+              canGoPrev={canPrev}
+              canGoNext={hasNext}
+              onFirst={onFirst}
+              onPrev={onPrev}
+              onNext={onNext}
+            />
+          </div>
+        </>
+      )}
+    </section>
+  );
+}
+
+ExploreResultsSection.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  articles: PropTypes.arrayOf(PropTypes.object).isRequired,
+  pageLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    .isRequired,
+  canPrev: PropTypes.bool.isRequired,
+  hasNext: PropTypes.bool.isRequired,
+  onFirst: PropTypes.func.isRequired,
+  onPrev: PropTypes.func.isRequired,
+  onNext: PropTypes.func.isRequired,
+  onDismiss: PropTypes.func,
+};

--- a/FrontEnd/src/components/mainPage/News.module.css
+++ b/FrontEnd/src/components/mainPage/News.module.css
@@ -108,6 +108,96 @@
     align-items: center;
 }
 
+/* 메인 — 탐색(Explore) 결과 */
+.ExploreSection {
+    width: min(75vw, 1200px);
+    margin: 0 auto 24px;
+    padding: 20px 16px 32px;
+    border-radius: 12px;
+    background: linear-gradient(180deg, #fafafa 0%, #fff 40%);
+    border: 1px solid #e8e8e8;
+    box-sizing: border-box;
+}
+
+@media (max-width: 900px) {
+    .ExploreSection {
+        width: 90vw;
+    }
+}
+
+.ExploreSection__head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 16px;
+}
+
+.ExploreSection__titles {
+    flex: 1 1 200px;
+    min-width: 0;
+}
+
+.ExploreSection__title {
+    font-size: clamp(17px, 1.8vw, 22px);
+    margin: 0 0 6px 0;
+}
+
+.ExploreSection__subtitle {
+    margin: 0;
+    font-size: clamp(12px, 1.25vw, 13px);
+    font-weight: 500;
+    color: #6b6b6b;
+    line-height: 1.45;
+    max-width: 52ch;
+}
+
+.ExploreSection__dismiss {
+    flex: 0 0 auto;
+    padding: 6px 12px;
+    font-size: 12px;
+    font-weight: 600;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    background: #fff;
+    cursor: pointer;
+}
+
+.ExploreSection__dismiss:hover {
+    background: #f3f3f3;
+}
+
+.ExploreSection__loading,
+.ExploreSection__empty {
+    margin: 16px 0;
+    color: #777;
+    font-size: 14px;
+}
+
+.ExploreSection__grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 10px;
+    align-items: start;
+}
+
+@media (max-width: 900px) {
+    .ExploreSection__grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 480px) {
+    .ExploreSection__grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.ExploreSection__pages {
+    width: 100%;
+    margin-top: 8px;
+}
 
 
 /* Search News */

--- a/FrontEnd/src/components/mainPage/SearchContainer.jsx
+++ b/FrontEnd/src/components/mainPage/SearchContainer.jsx
@@ -1,12 +1,20 @@
 import styled from "./SearchContainer.module.css";
 import PropTypes from "prop-types";
-import { Search } from "lucide-react";
+import { Search, SlidersHorizontal } from "lucide-react";
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
+import {
+  EXPLORE_COUNTRY_OPTIONS,
+  EXPLORE_CATEGORY_OPTIONS,
+} from "./exploreOptions";
 
-export default function SearchContainer({ searchTerm }) {
+export default function SearchContainer({
+  searchTerm,
+  enableExplore = false,
+  onExploreApply,
+}) {
   const navigate = useNavigate();
   const { language } = useLanguage();
   const [inputSearchTerm, setInputSearchTerm] = useState(searchTerm);
@@ -14,6 +22,11 @@ export default function SearchContainer({ searchTerm }) {
   const [placeholder, setPlaceholder] = useState("검색어를 입력해주세요 ");
   const [searchLabel, setSearchLabel] = useState("Search");
   const [isFocused, setIsFocused] = useState(false);
+
+  const [exploreOpen, setExploreOpen] = useState(false);
+  const [exCountry, setExCountry] = useState("");
+  const [exCategory, setExCategory] = useState("");
+  const [exDate, setExDate] = useState("");
 
   useEffect(() => {
     setInputSearchTerm(searchTerm);
@@ -53,6 +66,25 @@ export default function SearchContainer({ searchTerm }) {
     handleSearch();
   }
 
+  function buildExploreFilters() {
+    return {
+      ...(exCountry ? { country: exCountry } : {}),
+      ...(exCategory ? { category: exCategory } : {}),
+      ...(exDate ? { date: exDate } : {}),
+    };
+  }
+
+  async function handleExploreApplyClick() {
+    if (!onExploreApply) return;
+    await onExploreApply(buildExploreFilters());
+  }
+
+  function handleExploreReset() {
+    setExCountry("");
+    setExCategory("");
+    setExDate("");
+  }
+
   return (
     <div className={styled["searchContainer--container"]}>
       <div className={styled["searchContainer--searchBar"]}>
@@ -81,6 +113,7 @@ export default function SearchContainer({ searchTerm }) {
         </div>
         <button
           id="searchButton"
+          type="button"
           className={styled["searchContainer--searchButton"]}
           onClick={handleClickSearch}
           disabled={!value.trim()}
@@ -102,10 +135,90 @@ export default function SearchContainer({ searchTerm }) {
           </span>
         </button>
       </div>
+
+      {enableExplore && onExploreApply && (
+        <div className={styled["searchExplore__row"]}>
+          <button
+            type="button"
+            className={styled["searchExplore__toggle"]}
+            onClick={() => setExploreOpen((o) => !o)}
+            aria-expanded={exploreOpen}
+          >
+            <SlidersHorizontal size={16} aria-hidden />
+            탐색 조건
+          </button>
+
+          {exploreOpen && (
+            <div className={styled["searchExplore__panel"]}>
+              <p className={styled["searchExplore__hint"]}>
+                키워드 검색은 위 입력창에서 실행됩니다. 여기서는 국가·카테고리·날짜로
+                목록을 좁혀 볼 수 있습니다.
+              </p>
+              <div className={styled["searchExplore__grid"]}>
+                <div className={styled["searchExplore__field"]}>
+                  <label htmlFor="explore-country">국가</label>
+                  <select
+                    id="explore-country"
+                    value={exCountry}
+                    onChange={(e) => setExCountry(e.target.value)}
+                  >
+                    {EXPLORE_COUNTRY_OPTIONS.map((o) => (
+                      <option key={o.value || "all"} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className={styled["searchExplore__field"]}>
+                  <label htmlFor="explore-category">카테고리</label>
+                  <select
+                    id="explore-category"
+                    value={exCategory}
+                    onChange={(e) => setExCategory(e.target.value)}
+                  >
+                    {EXPLORE_CATEGORY_OPTIONS.map((o) => (
+                      <option key={o.value || "all-c"} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className={styled["searchExplore__field"]}>
+                  <label htmlFor="explore-date">날짜 (하루)</label>
+                  <input
+                    id="explore-date"
+                    type="date"
+                    value={exDate}
+                    onChange={(e) => setExDate(e.target.value)}
+                  />
+                </div>
+              </div>
+              <div className={styled["searchExplore__actions"]}>
+                <button
+                  type="button"
+                  className={styled["searchExplore__apply"]}
+                  onClick={handleExploreApplyClick}
+                >
+                  이 조건으로 보기
+                </button>
+                <button
+                  type="button"
+                  className={styled["searchExplore__reset"]}
+                  onClick={handleExploreReset}
+                >
+                  조건 초기화
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
 SearchContainer.propTypes = {
-  searchTerm: PropTypes.string.isRequired, // searchTerm은 string이어야 함
+  searchTerm: PropTypes.string.isRequired,
+  enableExplore: PropTypes.bool,
+  onExploreApply: PropTypes.func,
 };

--- a/FrontEnd/src/components/mainPage/SearchContainer.jsx
+++ b/FrontEnd/src/components/mainPage/SearchContainer.jsx
@@ -1,7 +1,7 @@
 import styled from "./SearchContainer.module.css";
 import PropTypes from "prop-types";
 import { Search, SlidersHorizontal } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
@@ -17,6 +17,8 @@ export default function SearchContainer({
 }) {
   const navigate = useNavigate();
   const { language } = useLanguage();
+  const exploreWrapRef = useRef(null);
+
   const [inputSearchTerm, setInputSearchTerm] = useState(searchTerm);
   const [value, setValue] = useState(searchTerm || "");
   const [placeholder, setPlaceholder] = useState("검색어를 입력해주세요 ");
@@ -27,6 +29,8 @@ export default function SearchContainer({
   const [exCountry, setExCountry] = useState("");
   const [exCategory, setExCategory] = useState("");
   const [exDate, setExDate] = useState("");
+
+  const hasExploreFilters = Boolean(exCountry || exCategory || exDate);
 
   useEffect(() => {
     setInputSearchTerm(searchTerm);
@@ -44,6 +48,20 @@ export default function SearchContainer({
     };
     translate();
   }, [language]);
+
+  useEffect(() => {
+    if (!exploreOpen) return;
+    function handlePointerDown(event) {
+      if (
+        exploreWrapRef.current &&
+        !exploreWrapRef.current.contains(event.target)
+      ) {
+        setExploreOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [exploreOpen]);
 
   function handleSearch() {
     const keyword = inputSearchTerm.trim();
@@ -77,6 +95,7 @@ export default function SearchContainer({
   async function handleExploreApplyClick() {
     if (!onExploreApply) return;
     await onExploreApply(buildExploreFilters());
+    setExploreOpen(false);
   }
 
   function handleExploreReset() {
@@ -85,134 +104,148 @@ export default function SearchContainer({
     setExDate("");
   }
 
+  const showExplore = enableExplore && onExploreApply;
+
   return (
     <div className={styled["searchContainer--container"]}>
-      <div className={styled["searchContainer--searchBar"]}>
-        <div className={styled["searchContainer--searchInputContainer"]}>
-          <Search className={styled["input-icon"]} size={20} />
-          <div className={styled["input-wrapper"]}>
-            <input
-              className={styled["searchContainer--Input"]}
-              value={value}
-              placeholder=""
-              onChange={handleInputChange}
-              onKeyDown={handleKeyDown}
-              onFocus={() => setIsFocused(true)}
-              onBlur={() => setIsFocused(false)}
-            />
-            {!value && !isFocused && (
-              <div className={styled["animated-placeholder"]}>
-                <span className={styled["placeholder-text"]}>
-                  {placeholder}
-                </span>
-                <span className={styled["emoji-sad"]}>😢</span>
-                <span className={styled["emoji-happy"]}>🥰</span>
-              </div>
+      <div
+        className={styled["searchExplore__wrap"]}
+        ref={exploreWrapRef}
+      >
+        <div className={styled["searchContainer--searchBar"]}>
+          <div className={styled["searchContainer--searchInputContainer"]}>
+            <Search className={styled["input-icon"]} size={20} />
+            <div className={styled["input-wrapper"]}>
+              <input
+                className={styled["searchContainer--Input"]}
+                value={value}
+                placeholder=""
+                onChange={handleInputChange}
+                onKeyDown={handleKeyDown}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+              />
+              {!value && !isFocused && (
+                <div className={styled["animated-placeholder"]}>
+                  <span className={styled["placeholder-text"]}>
+                    {placeholder}
+                  </span>
+                  <span className={styled["emoji-sad"]}>😢</span>
+                  <span className={styled["emoji-happy"]}>🥰</span>
+                </div>
+              )}
+            </div>
+            {showExplore && (
+              <button
+                type="button"
+                className={`${styled["searchExplore__trigger"]} ${exploreOpen ? styled["searchExplore__trigger--open"] : ""} ${hasExploreFilters ? styled["searchExplore__trigger--active"] : ""}`}
+                onClick={() => setExploreOpen((o) => !o)}
+                aria-expanded={exploreOpen}
+                aria-controls="explore-popover"
+                aria-label="탐색 조건 열기 · 국가·카테고리·날짜로 좁히기"
+                title="조건으로 좁히기"
+              >
+                <SlidersHorizontal size={20} strokeWidth={2.25} aria-hidden />
+                {hasExploreFilters && (
+                  <span className={styled["searchExplore__triggerDot"]} aria-hidden />
+                )}
+              </button>
             )}
           </div>
-        </div>
-        <button
-          id="searchButton"
-          type="button"
-          className={styled["searchContainer--searchButton"]}
-          onClick={handleClickSearch}
-          disabled={!value.trim()}
-        >
-          <span>{searchLabel}</span>
-          <span className={styled["btn-dots"]}>
-            <span
-              className={styled["btn-dot"]}
-              style={{ animationDelay: "0ms" }}
-            />
-            <span
-              className={styled["btn-dot"]}
-              style={{ animationDelay: "200ms" }}
-            />
-            <span
-              className={styled["btn-dot"]}
-              style={{ animationDelay: "400ms" }}
-            />
-          </span>
-        </button>
-      </div>
-
-      {enableExplore && onExploreApply && (
-        <div className={styled["searchExplore__row"]}>
           <button
+            id="searchButton"
             type="button"
-            className={styled["searchExplore__toggle"]}
-            onClick={() => setExploreOpen((o) => !o)}
-            aria-expanded={exploreOpen}
+            className={styled["searchContainer--searchButton"]}
+            onClick={handleClickSearch}
+            disabled={!value.trim()}
           >
-            <SlidersHorizontal size={16} aria-hidden />
-            탐색 조건
+            <span>{searchLabel}</span>
+            <span className={styled["btn-dots"]}>
+              <span
+                className={styled["btn-dot"]}
+                style={{ animationDelay: "0ms" }}
+              />
+              <span
+                className={styled["btn-dot"]}
+                style={{ animationDelay: "200ms" }}
+              />
+              <span
+                className={styled["btn-dot"]}
+                style={{ animationDelay: "400ms" }}
+              />
+            </span>
           </button>
+        </div>
 
-          {exploreOpen && (
-            <div className={styled["searchExplore__panel"]}>
-              <p className={styled["searchExplore__hint"]}>
-                키워드 검색은 위 입력창에서 실행됩니다. 여기서는 국가·카테고리·날짜로
-                목록을 좁혀 볼 수 있습니다.
-              </p>
-              <div className={styled["searchExplore__grid"]}>
-                <div className={styled["searchExplore__field"]}>
-                  <label htmlFor="explore-country">국가</label>
-                  <select
-                    id="explore-country"
-                    value={exCountry}
-                    onChange={(e) => setExCountry(e.target.value)}
-                  >
-                    {EXPLORE_COUNTRY_OPTIONS.map((o) => (
-                      <option key={o.value || "all"} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className={styled["searchExplore__field"]}>
-                  <label htmlFor="explore-category">카테고리</label>
-                  <select
-                    id="explore-category"
-                    value={exCategory}
-                    onChange={(e) => setExCategory(e.target.value)}
-                  >
-                    {EXPLORE_CATEGORY_OPTIONS.map((o) => (
-                      <option key={o.value || "all-c"} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div className={styled["searchExplore__field"]}>
-                  <label htmlFor="explore-date">날짜 (하루)</label>
-                  <input
-                    id="explore-date"
-                    type="date"
-                    value={exDate}
-                    onChange={(e) => setExDate(e.target.value)}
-                  />
-                </div>
+        {showExplore && exploreOpen && (
+          <div
+            className={styled["searchExplore__popover"]}
+            id="explore-popover"
+            role="dialog"
+            aria-label="탐색 조건"
+          >
+            <p className={styled["searchExplore__hint"]}>
+              키워드는 위 입력 후 검색 버튼 · 여기서는{" "}
+              <strong>국가·카테고리·날짜</strong>로 목록만 좁힙니다.
+            </p>
+            <div className={styled["searchExplore__grid"]}>
+              <div className={styled["searchExplore__field"]}>
+                <label htmlFor="explore-country">국가</label>
+                <select
+                  id="explore-country"
+                  value={exCountry}
+                  onChange={(e) => setExCountry(e.target.value)}
+                >
+                  {EXPLORE_COUNTRY_OPTIONS.map((o) => (
+                    <option key={o.value || "all"} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
               </div>
-              <div className={styled["searchExplore__actions"]}>
-                <button
-                  type="button"
-                  className={styled["searchExplore__apply"]}
-                  onClick={handleExploreApplyClick}
+              <div className={styled["searchExplore__field"]}>
+                <label htmlFor="explore-category">카테고리</label>
+                <select
+                  id="explore-category"
+                  value={exCategory}
+                  onChange={(e) => setExCategory(e.target.value)}
                 >
-                  이 조건으로 보기
-                </button>
-                <button
-                  type="button"
-                  className={styled["searchExplore__reset"]}
-                  onClick={handleExploreReset}
-                >
-                  조건 초기화
-                </button>
+                  {EXPLORE_CATEGORY_OPTIONS.map((o) => (
+                    <option key={o.value || "all-c"} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className={styled["searchExplore__field"]}>
+                <label htmlFor="explore-date">날짜 (하루)</label>
+                <input
+                  id="explore-date"
+                  type="date"
+                  value={exDate}
+                  onChange={(e) => setExDate(e.target.value)}
+                />
               </div>
             </div>
-          )}
-        </div>
-      )}
+            <div className={styled["searchExplore__actions"]}>
+              <button
+                type="button"
+                className={styled["searchExplore__apply"]}
+                onClick={handleExploreApplyClick}
+              >
+                이 조건으로 보기
+              </button>
+              <button
+                type="button"
+                className={styled["searchExplore__reset"]}
+                onClick={handleExploreReset}
+              >
+                조건 초기화
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/FrontEnd/src/components/mainPage/SearchContainer.jsx
+++ b/FrontEnd/src/components/mainPage/SearchContainer.jsx
@@ -1,7 +1,7 @@
 import styled from "./SearchContainer.module.css";
 import PropTypes from "prop-types";
 import { Search, SlidersHorizontal } from "lucide-react";
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
@@ -9,6 +9,20 @@ import {
   EXPLORE_COUNTRY_OPTIONS,
   EXPLORE_CATEGORY_OPTIONS,
 } from "./exploreOptions";
+
+const EXPLORE_UI_KEYS = {
+  hint: "키워드는 위 입력 후 검색 버튼을 누르세요. 여기서는 국가·카테고리·날짜로 목록만 좁힙니다.",
+  labelCountry: "국가",
+  labelCategory: "카테고리",
+  labelDate: "날짜 (하루)",
+  btnApply: "이 조건으로 보기",
+  btnReset: "조건 초기화",
+  all: "전체",
+  triggerTitle: "조건으로 좁히기",
+  triggerAria:
+    "탐색 조건 열기. 국가, 카테고리, 날짜로 목록을 좁힐 수 있습니다.",
+  dialogAria: "탐색 조건",
+};
 
 export default function SearchContainer({
   searchTerm,
@@ -30,7 +44,11 @@ export default function SearchContainer({
   const [exCategory, setExCategory] = useState("");
   const [exDate, setExDate] = useState("");
 
+  const [exUi, setExUi] = useState(() => ({ ...EXPLORE_UI_KEYS }));
+
   const hasExploreFilters = Boolean(exCountry || exCategory || exDate);
+
+  const showExplore = enableExplore && onExploreApply;
 
   useEffect(() => {
     setInputSearchTerm(searchTerm);
@@ -48,6 +66,26 @@ export default function SearchContainer({
     };
     translate();
   }, [language]);
+
+  useEffect(() => {
+    if (!showExplore) return;
+    let cancelled = false;
+    (async () => {
+      const entries = Object.entries(EXPLORE_UI_KEYS);
+      const translated = await Promise.all(
+        entries.map(([, ko]) => fetchTranslatedText(ko, language)),
+      );
+      if (cancelled) return;
+      const next = {};
+      entries.forEach(([key], i) => {
+        next[key] = translated[i];
+      });
+      setExUi(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [language, showExplore]);
 
   useEffect(() => {
     if (!exploreOpen) return;
@@ -104,7 +142,25 @@ export default function SearchContainer({
     setExDate("");
   }
 
-  const showExplore = enableExplore && onExploreApply;
+  const countryOptions = useMemo(
+    () =>
+      EXPLORE_COUNTRY_OPTIONS.map((o) =>
+        o.value === ""
+          ? { ...o, label: exUi.all }
+          : o,
+      ),
+    [exUi.all],
+  );
+
+  const categoryOptions = useMemo(
+    () =>
+      EXPLORE_CATEGORY_OPTIONS.map((o) =>
+        o.value === ""
+          ? { ...o, label: exUi.all }
+          : o,
+      ),
+    [exUi.all],
+  );
 
   return (
     <div className={styled["searchContainer--container"]}>
@@ -142,8 +198,8 @@ export default function SearchContainer({
                 onClick={() => setExploreOpen((o) => !o)}
                 aria-expanded={exploreOpen}
                 aria-controls="explore-popover"
-                aria-label="탐색 조건 열기 · 국가·카테고리·날짜로 좁히기"
-                title="조건으로 좁히기"
+                aria-label={exUi.triggerAria}
+                title={exUi.triggerTitle}
               >
                 <SlidersHorizontal size={20} strokeWidth={2.25} aria-hidden />
                 {hasExploreFilters && (
@@ -182,21 +238,18 @@ export default function SearchContainer({
             className={styled["searchExplore__popover"]}
             id="explore-popover"
             role="dialog"
-            aria-label="탐색 조건"
+            aria-label={exUi.dialogAria}
           >
-            <p className={styled["searchExplore__hint"]}>
-              키워드는 위 입력 후 검색 버튼 · 여기서는{" "}
-              <strong>국가·카테고리·날짜</strong>로 목록만 좁힙니다.
-            </p>
+            <p className={styled["searchExplore__hint"]}>{exUi.hint}</p>
             <div className={styled["searchExplore__grid"]}>
               <div className={styled["searchExplore__field"]}>
-                <label htmlFor="explore-country">국가</label>
+                <label htmlFor="explore-country">{exUi.labelCountry}</label>
                 <select
                   id="explore-country"
                   value={exCountry}
                   onChange={(e) => setExCountry(e.target.value)}
                 >
-                  {EXPLORE_COUNTRY_OPTIONS.map((o) => (
+                  {countryOptions.map((o) => (
                     <option key={o.value || "all"} value={o.value}>
                       {o.label}
                     </option>
@@ -204,13 +257,13 @@ export default function SearchContainer({
                 </select>
               </div>
               <div className={styled["searchExplore__field"]}>
-                <label htmlFor="explore-category">카테고리</label>
+                <label htmlFor="explore-category">{exUi.labelCategory}</label>
                 <select
                   id="explore-category"
                   value={exCategory}
                   onChange={(e) => setExCategory(e.target.value)}
                 >
-                  {EXPLORE_CATEGORY_OPTIONS.map((o) => (
+                  {categoryOptions.map((o) => (
                     <option key={o.value || "all-c"} value={o.value}>
                       {o.label}
                     </option>
@@ -218,7 +271,7 @@ export default function SearchContainer({
                 </select>
               </div>
               <div className={styled["searchExplore__field"]}>
-                <label htmlFor="explore-date">날짜 (하루)</label>
+                <label htmlFor="explore-date">{exUi.labelDate}</label>
                 <input
                   id="explore-date"
                   type="date"
@@ -233,14 +286,14 @@ export default function SearchContainer({
                 className={styled["searchExplore__apply"]}
                 onClick={handleExploreApplyClick}
               >
-                이 조건으로 보기
+                {exUi.btnApply}
               </button>
               <button
                 type="button"
                 className={styled["searchExplore__reset"]}
                 onClick={handleExploreReset}
               >
-                조건 초기화
+                {exUi.btnReset}
               </button>
             </div>
           </div>

--- a/FrontEnd/src/components/mainPage/SearchContainer.module.css
+++ b/FrontEnd/src/components/mainPage/SearchContainer.module.css
@@ -17,7 +17,7 @@
     flex-direction: row;
     align-items: stretch;
     gap: 12px;
-    margin-bottom: 20px;
+    margin-bottom: 0;
     box-sizing: border-box;
 }
 
@@ -192,43 +192,78 @@
     box-shadow: none;
 }
 
-/* 탐색(Explore) — 검색줄과 같은 너비에서 패널 */
-.searchExplore__row {
+/* 탐색(Explore) — 검색줄과 한 덩어리 + 팝오버 */
+.searchExplore__wrap {
+    position: relative;
     width: 100%;
     max-width: min(720px, calc(100vw - 32px));
-    margin-top: 10px;
+    margin-bottom: 20px;
 }
 
-.searchExplore__toggle {
-    display: inline-flex;
+.searchExplore__trigger {
+    position: relative;
+    flex: 0 0 auto;
+    display: flex;
     align-items: center;
-    gap: 6px;
-    padding: 8px 12px;
-    font-size: 12px;
-    font-weight: 700;
-    color: #333;
-    background: #f4f4f4;
-    border: 1px solid #d0d0d0;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    margin-left: 4px;
+    padding: 0;
+    border: none;
     border-radius: 8px;
+    background: transparent;
+    color: #565656;
     cursor: pointer;
+    transition: background-color 0.2s ease, color 0.2s ease;
 }
 
-.searchExplore__toggle:hover {
-    background: #ececec;
+.searchExplore__trigger:hover {
+    background: rgba(0, 0, 0, 0.06);
+    color: #333;
 }
 
-.searchExplore__toggle[aria-expanded="true"] {
-    border-color: rgb(255, 191, 53);
-    background: #fff8e6;
+.searchExplore__trigger--open {
+    background: rgba(240, 192, 64, 0.18);
+    color: #b8860b;
 }
 
-.searchExplore__panel {
-    margin-top: 12px;
-    padding: 14px 16px;
-    border-radius: 10px;
-    border: 1px solid #e0e0e0;
+.searchExplore__trigger--active:not(.searchExplore__trigger--open) {
+    color: #c9a227;
+}
+
+.searchExplore__triggerDot {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: rgb(255, 191, 53);
+    border: 1.5px solid #fff;
+}
+
+.searchExplore__popover {
+    margin-top: 10px;
+    padding: 14px 16px 16px;
+    border-radius: 12px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
     background: #fff;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    box-shadow:
+        0 4px 24px rgba(0, 0, 0, 0.1),
+        0 0 0 1px rgba(240, 192, 64, 0.12);
+    animation: searchExplorePopoverIn 0.18s ease-out;
+}
+
+@keyframes searchExplorePopoverIn {
+    from {
+        opacity: 0;
+        transform: translateY(-6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .searchExplore__hint {

--- a/FrontEnd/src/components/mainPage/SearchContainer.module.css
+++ b/FrontEnd/src/components/mainPage/SearchContainer.module.css
@@ -192,9 +192,114 @@
     box-shadow: none;
 }
 
+/* 탐색(Explore) — 검색줄과 같은 너비에서 패널 */
+.searchExplore__row {
+    width: 100%;
+    max-width: min(720px, calc(100vw - 32px));
+    margin-top: 10px;
+}
 
+.searchExplore__toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 700;
+    color: #333;
+    background: #f4f4f4;
+    border: 1px solid #d0d0d0;
+    border-radius: 8px;
+    cursor: pointer;
+}
 
+.searchExplore__toggle:hover {
+    background: #ececec;
+}
 
+.searchExplore__toggle[aria-expanded="true"] {
+    border-color: rgb(255, 191, 53);
+    background: #fff8e6;
+}
+
+.searchExplore__panel {
+    margin-top: 12px;
+    padding: 14px 16px;
+    border-radius: 10px;
+    border: 1px solid #e0e0e0;
+    background: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.searchExplore__hint {
+    margin: 0 0 12px;
+    font-size: 12px;
+    color: #666;
+    line-height: 1.4;
+}
+
+.searchExplore__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: 10px 14px;
+    align-items: end;
+}
+
+.searchExplore__field label {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    color: #555;
+    margin-bottom: 4px;
+}
+
+.searchExplore__field select,
+.searchExplore__field input[type="date"] {
+    width: 100%;
+    padding: 8px 10px;
+    font-size: 13px;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+    box-sizing: border-box;
+    background: #fff;
+}
+
+.searchExplore__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.searchExplore__apply {
+    padding: 8px 16px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #fff;
+    background: #2c2c2c;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.searchExplore__apply:hover {
+    background: #000;
+}
+
+.searchExplore__reset {
+    padding: 8px 14px;
+    font-size: 13px;
+    font-weight: 600;
+    color: #333;
+    background: #fff;
+    border: 1px solid #ccc;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.searchExplore__reset:hover {
+    background: #f5f5f5;
+}
 
 
 

--- a/FrontEnd/src/components/mainPage/exploreOptions.js
+++ b/FrontEnd/src/components/mainPage/exploreOptions.js
@@ -1,0 +1,28 @@
+/** 백엔드 Explore API·엔티티와 맞춘 예시 값 (country/category) */
+
+export const EXPLORE_COUNTRY_OPTIONS = [
+  { value: "", label: "전체" },
+  { value: "KR", label: "KR" },
+  { value: "US", label: "US" },
+  { value: "JP", label: "JP" },
+  { value: "GB", label: "GB" },
+  { value: "DE", label: "DE" },
+  { value: "FR", label: "FR" },
+  { value: "CN", label: "CN" },
+  { value: "IN", label: "IN" },
+  { value: "AU", label: "AU" },
+  { value: "CA", label: "CA" },
+  { value: "BR", label: "BR" },
+];
+
+export const EXPLORE_CATEGORY_OPTIONS = [
+  { value: "", label: "전체" },
+  { value: "general", label: "general" },
+  { value: "business", label: "business" },
+  { value: "sports", label: "sports" },
+  { value: "technology", label: "technology" },
+  { value: "health", label: "health" },
+  { value: "entertainment", label: "entertainment" },
+  { value: "science", label: "science" },
+  { value: "politics", label: "politics" },
+];

--- a/FrontEnd/src/pages/MainPage.jsx
+++ b/FrontEnd/src/pages/MainPage.jsx
@@ -1,14 +1,124 @@
-import styled from './MainPage.module.css';
-import SearchContainer from '../components/mainPage/SearchContainer';
-import MainNews from '../components/mainPage/MainNews';
+import styled from "./MainPage.module.css";
+import SearchContainer from "../components/mainPage/SearchContainer";
+import MainNews from "../components/mainPage/MainNews";
+import ExploreResultsSection from "../components/mainPage/ExploreResultsSection";
+import { useState, useCallback } from "react";
+import { getExploreArticles } from "../api/getNewsCardAPI";
+
+const EXPLORE_PAGE_SIZE = 12;
 
 export default function MainPage() {
+  const [exploreActive, setExploreActive] = useState(false);
+  const [exploreLoading, setExploreLoading] = useState(false);
+  const [exploreArticles, setExploreArticles] = useState([]);
+  const [exploreNextCursor, setExploreNextCursor] = useState(null);
+  const [exploreHasNext, setExploreHasNext] = useState(false);
+  const [exploreFilters, setExploreFilters] = useState({});
+  const [exploreStack, setExploreStack] = useState([]);
+  const [exploreRequestCursor, setExploreRequestCursor] = useState(null);
 
-    return(
-        <div className={styled['mainPage--container']}>
-            <SearchContainer searchTerm="" />
-            <MainNews />             
-        </div>
-    )
+  const applyExploreResponse = useCallback((res) => {
+    setExploreArticles(res.articles);
+    setExploreNextCursor(res.nextCursor);
+    setExploreHasNext(res.hasNext);
+  }, []);
+
+  const handleExploreApply = useCallback(
+    async (filters) => {
+      setExploreLoading(true);
+      setExploreActive(true);
+      setExploreFilters(filters);
+      const res = await getExploreArticles({
+        ...filters,
+        cursor: null,
+        size: EXPLORE_PAGE_SIZE,
+      });
+      applyExploreResponse(res);
+      setExploreStack([]);
+      setExploreRequestCursor(null);
+      setExploreLoading(false);
+    },
+    [applyExploreResponse],
+  );
+
+  const handleExploreFirst = useCallback(async () => {
+    setExploreLoading(true);
+    const res = await getExploreArticles({
+      ...exploreFilters,
+      cursor: null,
+      size: EXPLORE_PAGE_SIZE,
+    });
+    applyExploreResponse(res);
+    setExploreStack([]);
+    setExploreRequestCursor(null);
+    setExploreLoading(false);
+  }, [exploreFilters, applyExploreResponse]);
+
+  const handleExploreNext = useCallback(async () => {
+    if (!exploreHasNext || exploreNextCursor == null) return;
+    setExploreStack((s) => [...s, exploreRequestCursor]);
+    const res = await getExploreArticles({
+      ...exploreFilters,
+      cursor: exploreNextCursor,
+      size: EXPLORE_PAGE_SIZE,
+    });
+    applyExploreResponse(res);
+    setExploreRequestCursor(exploreNextCursor);
+  }, [
+    exploreHasNext,
+    exploreNextCursor,
+    exploreRequestCursor,
+    exploreFilters,
+    applyExploreResponse,
+  ]);
+
+  const handleExplorePrev = useCallback(async () => {
+    if (exploreStack.length === 0) return;
+    const parentCursor = exploreStack[exploreStack.length - 1];
+    setExploreStack((s) => s.slice(0, -1));
+    const res = await getExploreArticles({
+      ...exploreFilters,
+      cursor: parentCursor,
+      size: EXPLORE_PAGE_SIZE,
+    });
+    applyExploreResponse(res);
+    setExploreRequestCursor(parentCursor);
+  }, [exploreStack, exploreFilters, applyExploreResponse]);
+
+  const handleExploreDismiss = useCallback(() => {
+    setExploreActive(false);
+    setExploreArticles([]);
+    setExploreNextCursor(null);
+    setExploreHasNext(false);
+    setExploreFilters({});
+    setExploreStack([]);
+    setExploreRequestCursor(null);
+  }, []);
+
+  const explorePageLabel = exploreStack.length + 1;
+  const canExplorePrev = exploreStack.length > 0;
+
+  return (
+    <div className={styled["mainPage--container"]}>
+      <SearchContainer
+        searchTerm=""
+        enableExplore
+        onExploreApply={handleExploreApply}
+      />
+      {exploreActive && (
+        <ExploreResultsSection
+          loading={exploreLoading}
+          articles={exploreArticles}
+          pageLabel={explorePageLabel}
+          canPrev={canExplorePrev}
+          hasNext={exploreHasNext}
+          onFirst={handleExploreFirst}
+          onPrev={handleExplorePrev}
+          onNext={handleExploreNext}
+          onDismiss={handleExploreDismiss}
+        />
+      )}
+      <MainNews />
+    </div>
+  );
 }
-


### PR DESCRIPTION
## 목적

1. **조건 탐색 UX**: 메인 검색창 옆 탐색(슬라이더) 툴팁 추가 ( 단 탐색과 검색은 지금 별개의 동작이라, 탐색 이후 검색의 연계는 API 수정이 필요 )

2. 하드 코딩 된 부분 : 전역 언어에 맞게 표시하도록 수정 : 위 문구와 탐색 패널 전반, 커서 페이지네이션 접근성 문구를 헤더 전역 언어(`LanguageContext`)에 맞게 `fetchTranslatedText`로 번역해 표시한다.

## 참고

- `ExploreResultsSection` 등 기존 `TranslatedText` 사용 부분과 별개로, `SearchContainer` / `CursorPagination`은 `fetchTranslatedText` + `useEffect` 배치 번역으로 통일.
- 탐색 API·최신순 동작은 기존 `/api/articles/explore` 스펙과 동일(날짜 미지정 시 날짜 필터 없음, `publishedAt` 내림차순).

## 커밋 메시지 (참고 · 묶음)

**조건 탐색 툴팁·안내**

feat(ui): 메인 검색 탐색 트리거 툴팁·접근성 라벨 및 팝오버 안내 문구 추가

**다국어**
feat: 메인 탐색·커서 페이지네이션 UI 다국어 연동

SearchContainer: 탐색 트리거 title/aria, 팝오버 힌트·라벨·버튼 번역
국가/카테고리 "전체" 옵션 라벨 번역
CursorPagination: 페이지네이션 접근성 문구 동적 번역