### PR TITLE
[FEAT] 프론트 UI 전역 언어 설정 연동 및 기본 언어 API 최적화(한)

### DIFF
--- a/FrontEnd/src/api/TranslatedText.jsx
+++ b/FrontEnd/src/api/TranslatedText.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useLanguage } from "../util/LanguageContext";
 import axios from "axios";
+import { DEFAULT_UI_LANGUAGE } from "../constants/uiLanguage.js";
 
 // HTML 엔티티 디코딩 함수
 const decodeHTMLEntities = (text) => {
@@ -42,6 +43,11 @@ const TranslatedText = ({ text }) => {
                 .replace(/\u2018/g, "'")
                 .replace(/\u2026/g, "...")
                 .replace(/[\u201C\u201D]/g, '"');
+
+            if (language === DEFAULT_UI_LANGUAGE) {
+                setTranslated(cleanedText);
+                return;
+            }
 
             // 캐시 히트 시 API 호출 없이 반환
             const cached = getCache(cleanedText, language);

--- a/FrontEnd/src/api/fetchTranslatedText.jsx
+++ b/FrontEnd/src/api/fetchTranslatedText.jsx
@@ -1,5 +1,5 @@
 import axios from "axios";
-
+import { DEFAULT_UI_LANGUAGE } from "../constants/uiLanguage.js";
 
 // HTML 엔티티 디코딩 함수
 const decodeHTMLEntities = (text) => {
@@ -9,6 +9,9 @@ const decodeHTMLEntities = (text) => {
 };
 
 export const fetchTranslatedText = async (text, language) => {
+    if (text == null || text === "") return text ?? "";
+    if (language === DEFAULT_UI_LANGUAGE) return text;
+
     const cleanedText = text
       .replace(/’/g, "'")
       .replace(/…/g, "...")

--- a/FrontEnd/src/components/chat/ChatHistoryButton.jsx
+++ b/FrontEnd/src/components/chat/ChatHistoryButton.jsx
@@ -5,9 +5,14 @@ import ReactMarkdown from "react-markdown";
 import { useAuth } from "../../util/AuthContext.jsx";
 import { getChatList } from "../../api/chatAPI.js";
 import styles from "./ChatHistoryButton.module.css";
+import TranslatedText from "../../api/TranslatedText.jsx";
+import { useLanguage } from "../../util/LanguageContext.jsx";
+import { useTranslatedLabel } from "../../hooks/useTranslatedLabel.js";
 
 export default function ChatHistoryButton() {
     const { token } = useAuth();
+    const { language } = useLanguage();
+    const fabLabel = useTranslatedLabel("채팅 히스토리");
     const navigate = useNavigate();
     const [isOpen, setIsOpen] = useState(false);
     const [chatList, setChatList] = useState([]);
@@ -37,13 +42,18 @@ export default function ChatHistoryButton() {
         return () => document.removeEventListener("mousedown", handleClickOutside);
     }, [isOpen]);
 
+    const dateLocale =
+        language === "ja" ? "ja-JP" : language === "ko" ? "ko-KR" : "en-US";
+
     return (
         <div className={styles.wrapper} ref={popupRef}>
             {/* 팝업 */}
             {isOpen && (
                 <div className={styles.popup}>
                     <div className={styles.popupHeader}>
-                        <span>채팅 히스토리</span>
+                        <span>
+                            <TranslatedText text="채팅 히스토리" />
+                        </span>
                         <button onClick={() => setIsOpen(false)} className={styles.closeBtn}>
                             <X size={16} />
                         </button>
@@ -54,7 +64,9 @@ export default function ChatHistoryButton() {
                             <div className={styles.loginPrompt}>
                                 <MessageSquare size={36} className={styles.promptIcon} />
                                 <p className={styles.promptText}>
-                                    로그인하면 기사별 AI 대화 내역을<br />언제든지 다시 볼 수 있어요.
+                                    <TranslatedText text="로그인하면 기사별 AI 대화 내역을" />
+                                    <br />
+                                    <TranslatedText text="언제든지 다시 볼 수 있어요." />
                                 </p>
                                 <button
                                     className={styles.loginBtn}
@@ -63,15 +75,21 @@ export default function ChatHistoryButton() {
                                         window.location.href = "/oauth2/authorization/google";
                                     }}
                                 >
-                                    Google로 로그인
+                                    <TranslatedText text="Google로 로그인" />
                                 </button>
                             </div>
                         )}
 
                         {/* 로그인 상태 */}
-                        {token && isLoading && <p className={styles.empty}>불러오는 중...</p>}
+                        {token && isLoading && (
+                            <p className={styles.empty}>
+                                <TranslatedText text="불러오는 중..." />
+                            </p>
+                        )}
                         {token && !isLoading && chatList.length === 0 && (
-                            <p className={styles.empty}>저장된 대화 내역이 없습니다.</p>
+                            <p className={styles.empty}>
+                                <TranslatedText text="저장된 대화 내역이 없습니다." />
+                            </p>
                         )}
                         {token && !isLoading && chatList.map((item) => (
                             <div
@@ -97,7 +115,7 @@ export default function ChatHistoryButton() {
                                         <ReactMarkdown>{item.lastAnswerPreview}</ReactMarkdown>
                                     </div>
                                     <p className={styles.time}>
-                                        {new Date(item.lastChatAt).toLocaleString("ko-KR")}
+                                        {new Date(item.lastChatAt).toLocaleString(dateLocale)}
                                     </p>
                                 </div>
                             </div>
@@ -110,7 +128,8 @@ export default function ChatHistoryButton() {
             <button
                 className={styles.fab}
                 onClick={() => setIsOpen((prev) => !prev)}
-                title="채팅 히스토리"
+                title={fabLabel}
+                aria-label={fabLabel}
             >
                 <MessageSquare size={22} />
             </button>

--- a/FrontEnd/src/components/commons/footer/Footer.jsx
+++ b/FrontEnd/src/components/commons/footer/Footer.jsx
@@ -1,4 +1,5 @@
 import styles from "./Footer.module.css";
+import TranslatedText from "../../../api/TranslatedText.jsx";
 
 export default function Footer() {
   return (
@@ -6,20 +7,26 @@ export default function Footer() {
       <h2>GLOBAL TIMES</h2>
       <footer className={styles.footer}>
         <div className={styles.links}>
-          <p>오류신고</p>
+          <p>
+            <TranslatedText text="오류신고" />
+          </p>
           <p>|</p>
-          <p>서비스안내</p>
+          <p>
+            <TranslatedText text="서비스안내" />
+          </p>
           <p>|</p>
-          <p>책임자 </p>
+          <p>
+            <TranslatedText text="책임자 " />
+          </p>
         </div>
-        <div className={styles.info}>각 언론사가 직접 콘텐츠를 편집합니다.</div>
-        <div className={styles.copyright}>
-          이 콘텐츠의 저작권은 저작권자 또는 제공처에 있으며, 무단 이용하는 경우
-          저작권법 등에 따라 법적 책임을 질 수 있습니다.
+        <div className={styles.info}>
+          <TranslatedText text="각 언론사가 직접 콘텐츠를 편집합니다." />
         </div>
         <div className={styles.copyright}>
-          트랜드 데이터는 Google의 서비스 정책 및 저작권 보호 하에 있으며, 상업적
-          이용 시에는 Google의 명시적인 허가가 필요할 수 있습니다.
+          <TranslatedText text="이 콘텐츠의 저작권은 저작권자 또는 제공처에 있으며, 무단 이용하는 경우 저작권법 등에 따라 법적 책임을 질 수 있습니다." />
+        </div>
+        <div className={styles.copyright}>
+          <TranslatedText text="트랜드 데이터는 Google의 서비스 정책 및 저작권 보호 하에 있으며, 상업적 이용 시에는 Google의 명시적인 허가가 필요할 수 있습니다." />
         </div>
       </footer>
     </div>

--- a/FrontEnd/src/components/commons/header/Header.jsx
+++ b/FrontEnd/src/components/commons/header/Header.jsx
@@ -6,6 +6,7 @@ import { useLanguage } from "../../../util/LanguageContext.jsx";
 import { useAuth } from "../../../util/AuthContext.jsx";
 import TranslatedText from "../../../api/TranslatedText.jsx";
 import LanguageSelect from "./LanguageSelect.jsx";
+import { useTranslatedLabel } from "../../../hooks/useTranslatedLabel.js";
 
 export default function Header() {
   const navigate = useNavigate();
@@ -21,12 +22,9 @@ export default function Header() {
 
   const isHome = location.pathname === "/" || location.pathname === "/intro";
 
-  const logoTooltipLabel =
-    language === "en"
-      ? "Live trends check"
-      : language === "ja"
-        ? "リアルタイムトレンド 確認"
-        : "실시간 트렌드 확인하기";
+  const logoTooltipLabel = useTranslatedLabel("실시간 트렌드 확인하기");
+  const logoAriaLabel = useTranslatedLabel("홈 · 실시간 트렌드로 이동");
+  const menuOpenAriaLabel = useTranslatedLabel("메뉴 열기");
 
   const navItems = [
     { label: "메인페이지", path: "/main" },
@@ -58,7 +56,7 @@ export default function Header() {
           }}
           role="button"
           tabIndex={0}
-          aria-label="홈 · 실시간 트렌드로 이동"
+          aria-label={logoAriaLabel}
         >
           <img src={Logo} className={styles.image} alt="" draggable={false} />
           <span
@@ -132,7 +130,7 @@ export default function Header() {
         <button
           className={`${styles.hamburger} ${menuOpen ? styles.hamburgerOpen : ""}`}
           onClick={() => setMenuOpen(!menuOpen)}
-          aria-label="메뉴 열기"
+          aria-label={menuOpenAriaLabel}
         >
           <span />
           <span />

--- a/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
+++ b/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
@@ -6,12 +6,16 @@ import ReactMarkdown from "react-markdown";
 
 import TranslatedText from "../../api/TranslatedText.jsx";
 import { useAuth } from "../../util/AuthContext.jsx";
+import { useLanguage } from "../../util/LanguageContext.jsx";
+import { useTranslatedLabel } from "../../hooks/useTranslatedLabel.js";
 import { toggleScrap, getScrapStatus } from "../../api/scrapAPI.js";
 
 export default function ArticleDetail({ id, newsDetail, content, isLoading, isSummaryLoading }) {
   const articleId = Number(id);
   const { title, author, sourceName, publishedAt, viewCount, urlToImage } = newsDetail;
   const { token } = useAuth();
+  const { language } = useLanguage();
+  const imageAlt = useTranslatedLabel("기사 이미지");
 
   const [isScrapped, setIsScrapped] = useState(false);
   const [showModal, setShowModal] = useState(false);
@@ -57,6 +61,9 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading, isSu
   // 제목 말줄임 (모달용)
   const shortTitle = title && title.length > 22 ? title.slice(0, 22) + "..." : title;
 
+  const dateLocale =
+    language === "ja" ? "ja-JP" : language === "ko" ? "ko-KR" : "en-US";
+
   return (
     <div className={styles.articleDetail}>
 
@@ -92,7 +99,7 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading, isSu
       <h1><TranslatedText text={title}/></h1>
       <div className={styles.infoContainer}>
         <p className={styles.timeText}>
-          <TranslatedText text={new Date(publishedAt).toLocaleString()}/>
+          {new Date(publishedAt).toLocaleString(dateLocale)}
         </p>
         <div className={styles.stats}>
           <span><TranslatedText text="조회수"/>{viewCount}</span>
@@ -110,7 +117,7 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading, isSu
       <p className={styles.meta}>
         {sourceName} - {author}
       </p>
-      <img src={urlToImage} alt="기사 이미지" className={styles.image} />
+      <img src={urlToImage} alt={imageAlt} className={styles.image} />
       {/* 기사 요약내용 - 상세 정보와 독립적으로 로딩 */}
       {isSummaryLoading ? (
          <MutatingDots 
@@ -127,7 +134,9 @@ export default function ArticleDetail({ id, newsDetail, content, isLoading, isSu
              <ReactMarkdown>{content}</ReactMarkdown>
            </div>
          ) : (
-           <p className={styles.content}>요약 정보를 불러올 수 없습니다.</p>
+           <p className={styles.content}>
+             <TranslatedText text="요약 정보를 불러올 수 없습니다." />
+           </p>
          )
        }
     </div>

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -8,6 +8,7 @@ import { getChatsByArticle } from "../../api/chatAPI.js";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import { useAuth } from "../../util/AuthContext.jsx";
+import TranslatedText from "../../api/TranslatedText.jsx";
 
 export default function Chatbot({ articleId }) {
     const [input, setInput] = useState("");
@@ -40,9 +41,9 @@ export default function Chatbot({ articleId }) {
                     });
                     setMessages([
                         { type: "bot", text: translatedGreeting },
-                        { type: "divider", text: "── 이전 대화 내역 ──" },
+                        { type: "divider", kind: "history" },
                         ...historyMessages,
-                        { type: "divider", text: "── 새 대화 ──" },
+                        { type: "divider", kind: "new" },
                     ]);
                 } else {
                     setMessages([{ type: "bot", text: translatedGreeting }]);
@@ -93,7 +94,11 @@ export default function Chatbot({ articleId }) {
                 setMessages((prev) => {
                     const updated = [...prev];
                     if (updated[updated.length - 1].text === "") {
-                        updated[updated.length - 1] = { type: "bot", text: "응답을 가져오는 데 실패했습니다." };
+                        updated[updated.length - 1] = {
+                            type: "bot",
+                            text: "",
+                            fetchError: true,
+                        };
                     }
                     return updated;
                 });
@@ -113,13 +118,31 @@ export default function Chatbot({ articleId }) {
             <div className={styles.chatHeader}>Global AI</div>
             {!token && (
                 <div className={styles.loginNotice}>
-                    💡 로그인하면 대화 내역이 저장되고 문맥이 이어집니다.
+                    <span aria-hidden>💡 </span>
+                    <TranslatedText text="로그인하면 대화 내역이 저장되고 문맥이 이어집니다." />
                 </div>
             )}
             <div className={styles.chatBody} ref={chatRef}>
                 {messages.map((msg, index) => {
                     if (msg.type === "divider") {
-                        return <div key={index} className={styles.divider}>{msg.text}</div>;
+                        return (
+                            <div key={index} className={styles.divider}>
+                                <TranslatedText
+                                    text={
+                                        msg.kind === "history"
+                                            ? "── 이전 대화 내역 ──"
+                                            : "── 새 대화 ──"
+                                    }
+                                />
+                            </div>
+                        );
+                    }
+                    if (msg.type === "bot" && msg.fetchError) {
+                        return (
+                            <div key={index} className={styles.botMessage}>
+                                <TranslatedText text="응답을 가져오는 데 실패했습니다." />
+                            </div>
+                        );
                     }
                     return (
                         <div key={index} className={msg.type === "bot" ? styles.botMessage : styles.userMessage}>
@@ -130,7 +153,9 @@ export default function Chatbot({ articleId }) {
                         </div>
                     );
                 })}
-                {isStreaming && messages[messages.length - 1]?.text === "" && (
+                {isStreaming &&
+                    messages[messages.length - 1]?.text === "" &&
+                    !messages[messages.length - 1]?.fetchError && (
                     <div className={styles.botMessage}>
                         <span className={styles.typingIndicator}>
                             <span /><span /><span />

--- a/FrontEnd/src/components/globe/TrendModal.jsx
+++ b/FrontEnd/src/components/globe/TrendModal.jsx
@@ -1,16 +1,22 @@
-import { useEffect, useState } from "react";
 import styles from "./TrendModal.module.css";
-
-//번역 컴포넌트
 import TranslatedText from "../../api/TranslatedText";
+import { useLanguage } from "../../util/LanguageContext.jsx";
 
 const TrendModal = ({ country, trends, timestamp, onSelect, onClose }) => {
+  const { language } = useLanguage();
+  const dateLocale =
+    language === "ja" ? "ja-JP" : language === "ko" ? "ko-KR" : "en-US";
+
   return (
     <div className={styles.trendModal}>
       <div className={styles.titleContainer}>
-        <h3><TranslatedText text={`${country}의 실시간 트렌드`}/></h3>
+        <h3>
+          <TranslatedText text={`${country}의 실시간 트렌드`} />
+        </h3>
         <p className={styles.dateTime}>
-          <TranslatedText text={`업데이트: ${new Date(timestamp).toLocaleString()}`}/></p>
+          <TranslatedText text="업데이트:" />{" "}
+          {new Date(timestamp).toLocaleString(dateLocale)}
+        </p>
       </div>
 
       <ul>
@@ -21,13 +27,16 @@ const TrendModal = ({ country, trends, timestamp, onSelect, onClose }) => {
         ))}
       </ul>
 
-      {/* 저작권 문구 추가 */}
       <p className={styles.copyright}>
-        <TranslatedText text="본 페이지에 표시된 트렌드 데이터는 "/>
-        <a href="https://trends.google.com/trends/" target="_blank" rel="noopener noreferrer">
+        <TranslatedText text="본 페이지에 표시된 트렌드 데이터는 " />
+        <a
+          href="https://trends.google.com/trends/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Google Trends
         </a>
-        <TranslatedText text="에서 제공하는 RSS 피드를 기반으로 수집되었습니다."/>        
+        <TranslatedText text="에서 제공하는 RSS 피드를 기반으로 수집되었습니다." />
       </p>
     </div>
   );

--- a/FrontEnd/src/components/intro/bottom/IntroBottom.jsx
+++ b/FrontEnd/src/components/intro/bottom/IntroBottom.jsx
@@ -5,7 +5,7 @@ import styles from "./IntroBottom.module.css";
 
 //번역 컴포넌트
 import TranslatedText from "../../../api/TranslatedText";
-
+import { useTranslatedLabel } from "../../../hooks/useTranslatedLabel.js";
 
 // img
 import teamImg from "../../../assets/ourWorksImg.jpg";
@@ -17,6 +17,8 @@ import teamImage5 from "../../../assets/team11.jpg";
 import teamImage6 from "../../../assets/team12.jpg";
 
 export default function IntroBottom(){
+    const teamPhotoAlt = useTranslatedLabel("팀 사진...");
+
     useEffect(() => {
         AOS.init({
           duration: 800, // 애니메이션 지속 시간
@@ -35,7 +37,7 @@ export default function IntroBottom(){
                     <span> <TranslatedText text="프론트엔드 개발자와 백엔드 개발자로 이루어진 저희 팀은, 각 분야 팀원들끼리 많은 소통을 통해 프로젝트를 더욱 꼼꼼하고 효율적으로 진행해오고 있습니다."/></span>
                 </div>
                 <div className={styles["imgDiv"]} data-aos="fade-left" data-aos-offset="250">
-                    <img src={teamImg} alt="팀 사진..."/>
+                    <img src={teamImg} alt={teamPhotoAlt}/>
                 </div>
             </div>
 

--- a/FrontEnd/src/components/intro/top/IntroTopAnimation.jsx
+++ b/FrontEnd/src/components/intro/top/IntroTopAnimation.jsx
@@ -1,7 +1,9 @@
 import { motion } from "framer-motion";
 import styles from "./IntroTop.module.css";
+import { useTranslatedLabel } from "../../../hooks/useTranslatedLabel.js";
 
 export default function IntroAnimation({ isVisible, title, description, imgSrc, isMobile }) {
+    const loadingAlt = useTranslatedLabel("로딩중...");
 
     if (isMobile) {
         return (
@@ -11,7 +13,7 @@ export default function IntroAnimation({ isVisible, title, description, imgSrc, 
                     <span dangerouslySetInnerHTML={{ __html: description }} />
                 </div>
                 <div className={styles["imgDiv"]}>
-                    <img src={imgSrc} alt="로딩중..." />
+                    <img src={imgSrc} alt={loadingAlt} />
                 </div>
             </div>
         );
@@ -32,7 +34,7 @@ export default function IntroAnimation({ isVisible, title, description, imgSrc, 
           <span dangerouslySetInnerHTML={{ __html: description }} />
         </div>
         <div className={styles["imgDiv"]}>
-          <img src={imgSrc} alt="로딩중..." />
+          <img src={imgSrc} alt={loadingAlt} />
         </div>
       </motion.div>
     );

--- a/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
+++ b/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
@@ -3,6 +3,7 @@ import BasicNewsCard from "../newsCard/BasicNewsCard";
 import CursorPagination from "./CursorPagination";
 import TranslatedText from "../../api/TranslatedText";
 import PropTypes from "prop-types";
+import { useTranslatedLabel } from "../../hooks/useTranslatedLabel.js";
 
 export default function ExploreResultsSection({
   loading,
@@ -15,8 +16,10 @@ export default function ExploreResultsSection({
   onNext,
   onDismiss,
 }) {
+  const exploreSectionAria = useTranslatedLabel("탐색 결과");
+
   return (
-    <section className={styled["ExploreSection"]} aria-label="탐색 결과">
+    <section className={styled["ExploreSection"]} aria-label={exploreSectionAria}>
       <div className={styled["ExploreSection__head"]}>
         <div className={styled["ExploreSection__titles"]}>
           <h2 className={styled["ExploreSection__title"]}>

--- a/FrontEnd/src/components/mainPage/Pagenation.jsx
+++ b/FrontEnd/src/components/mainPage/Pagenation.jsx
@@ -1,14 +1,46 @@
-import styled from './Pagenation.module.css';
-import PropTypes from 'prop-types';
+import styled from "./Pagenation.module.css";
+import PropTypes from "prop-types";
+import { useState, useEffect } from "react";
+import { useLanguage } from "../../util/LanguageContext.jsx";
+import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 
-function Pagenation({ currentPage, totalPages, onPageChange}) {
+const PAGE_UI_KO = {
+  first: "첫 페이지",
+  prev: "이전 페이지",
+  pagePrefix: "페이지",
+  next: "다음 페이지",
+  last: "마지막 페이지",
+};
+
+function Pagenation({ currentPage, totalPages, onPageChange }) {
+  const { language } = useLanguage();
+  const [ui, setUi] = useState(() => ({ ...PAGE_UI_KO }));
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const entries = Object.entries(PAGE_UI_KO);
+      const translated = await Promise.all(
+        entries.map(([, ko]) => fetchTranslatedText(ko, language)),
+      );
+      if (cancelled) return;
+      const next = {};
+      entries.forEach(([key], i) => {
+        next[key] = translated[i];
+      });
+      setUi(next);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [language]);
 
   function firstClick() {
     if (currentPage !== 1) {
       onPageChange(1);
     }
   }
-  
+
   function lastClick() {
     if (currentPage !== totalPages) {
       onPageChange(totalPages);
@@ -17,51 +49,45 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
 
   function getPageNumbers() {
     const pages = [];
-  
+
     if (totalPages <= 5) {
-      // 전체 페이지가 5 이하라면 그냥 다 보여줘
       for (let i = 1; i <= totalPages; i++) {
         pages.push(i);
       }
     } else {
-      pages.push(1); // 첫 페이지는 무조건
-  
+      pages.push(1);
+
       if (currentPage > 3) {
-        pages.push('...'); // 왼쪽 점
+        pages.push("...");
       }
-  
-      // 현재 페이지 기준 앞뒤로 보여줄 페이지
+
       const start = Math.max(2, currentPage - 1);
       const end = Math.min(totalPages - 1, currentPage + 1);
-  
+
       for (let i = start; i <= end; i++) {
         pages.push(i);
       }
-  
+
       if (currentPage < totalPages - 2) {
-        pages.push('...'); // 오른쪽 점
+        pages.push("...");
       }
-  
-      pages.push(totalPages); // 마지막 페이지는 무조건
+
+      pages.push(totalPages);
     }
-  
+
     return pages;
   }
 
-
-
-  // 페이지 화살표
   function prevClick() {
-    if(currentPage > 1) {
-      onPageChange(currentPage-1);
+    if (currentPage > 1) {
+      onPageChange(currentPage - 1);
     }
   }
   function nextClick() {
-    if (currentPage<totalPages){
+    if (currentPage < totalPages) {
       onPageChange(currentPage + 1);
     }
   }
-
 
   const canPrev = currentPage > 1;
   const canNext = currentPage < totalPages;
@@ -73,8 +99,8 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
         className={styled.pagenationButton}
         onClick={firstClick}
         disabled={!canPrev}
-        aria-label="첫 페이지"
-        title="첫 페이지"
+        aria-label={ui.first}
+        title={ui.first}
       >
         ≪
       </button>
@@ -83,14 +109,14 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
         className={styled.pagenationButton}
         onClick={prevClick}
         disabled={!canPrev}
-        aria-label="이전 페이지"
-        title="이전 페이지"
+        aria-label={ui.prev}
+        title={ui.prev}
       >
         &lt;
       </button>
 
       {getPageNumbers().map((pageNumber, index) =>
-        pageNumber === '...' ? (
+        pageNumber === "..." ? (
           <span key={`ellipsis-${index}`} className={styled.ellipsis}>
             ...
           </span>
@@ -98,14 +124,14 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
           <button
             type="button"
             key={pageNumber}
-            className={`${styled.pagenationButton} ${pageNumber === currentPage ? styled.activePage : ''}`}
+            className={`${styled.pagenationButton} ${pageNumber === currentPage ? styled.activePage : ""}`}
             onClick={() => onPageChange(pageNumber)}
-            aria-label={`페이지 ${pageNumber}`}
-            aria-current={pageNumber === currentPage ? 'page' : undefined}
+            aria-label={`${ui.pagePrefix} ${pageNumber}`}
+            aria-current={pageNumber === currentPage ? "page" : undefined}
           >
             {pageNumber}
           </button>
-        )
+        ),
       )}
 
       <button
@@ -113,8 +139,8 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
         className={styled.pagenationButton}
         onClick={nextClick}
         disabled={!canNext}
-        aria-label="다음 페이지"
-        title="다음 페이지"
+        aria-label={ui.next}
+        title={ui.next}
       >
         &gt;
       </button>
@@ -123,8 +149,8 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
         className={styled.pagenationButton}
         onClick={lastClick}
         disabled={!canNext}
-        aria-label="마지막 페이지"
-        title="마지막 페이지"
+        aria-label={ui.last}
+        title={ui.last}
       >
         ≫
       </button>
@@ -134,12 +160,8 @@ function Pagenation({ currentPage, totalPages, onPageChange}) {
 
 export default Pagenation;
 
-
-
-
 Pagenation.propTypes = {
-    currentPage: PropTypes.number.isRequired,
-    totalPages: PropTypes.number.isRequired,
-    onPageChange: PropTypes.func.isRequired
+  currentPage: PropTypes.number.isRequired,
+  totalPages: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
 };
-

--- a/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
@@ -4,6 +4,7 @@ import styled from "./NewsCard.module.css";
 import { useNavigate } from "react-router-dom";
 import TranslatedText from '../../api/TranslatedText';
 import { useAuth } from '../../util/AuthContext';
+import { useTranslatedLabel } from '../../hooks/useTranslatedLabel.js';
 import { toggleScrap as toggleScrapAPI } from '../../api/scrapAPI';
 import { FaBookmark, FaTimes } from 'react-icons/fa';
 
@@ -12,6 +13,7 @@ export default function ScrapNewsCard({ id, press, title, summary, image, year, 
     const { token } = useAuth();
     const navigate = useNavigate();
     const [showModal, setShowModal] = useState(false);
+    const removeBtnTitle = useTranslatedLabel("스크랩 취소");
 
     const shortTitle = title && title.length > 20 ? title.slice(0, 20) + "..." : title;
 
@@ -94,7 +96,7 @@ export default function ScrapNewsCard({ id, press, title, summary, image, year, 
                 <button
                     className={styled['ScrapNewsCard--removeBtn']}
                     onClick={handleRemoveClick}
-                    title="스크랩 취소"
+                    title={removeBtnTitle}
                 >
                     <FaTimes />
                 </button>

--- a/FrontEnd/src/constants/uiLanguage.js
+++ b/FrontEnd/src/constants/uiLanguage.js
@@ -1,0 +1,2 @@
+/** UI 원문·기본값이 한국어일 때 번역 API를 호출하지 않기 위한 기준 코드 */
+export const DEFAULT_UI_LANGUAGE = "ko";

--- a/FrontEnd/src/hooks/useTranslatedLabel.js
+++ b/FrontEnd/src/hooks/useTranslatedLabel.js
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+import { useLanguage } from "../util/LanguageContext.jsx";
+import { fetchTranslatedText } from "../api/fetchTranslatedText.jsx";
+
+/**
+ * 속성 aria-label / title / img alt 등 단일 문자열용.
+ * 기본 언어(ko)는 fetchTranslatedText 내부에서 API 미호출.
+ */
+export function useTranslatedLabel(koreanText) {
+  const { language } = useLanguage();
+  const [label, setLabel] = useState(koreanText);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const t = await fetchTranslatedText(koreanText, language);
+      if (!cancelled) setLabel(t);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [koreanText, language]);
+
+  return label;
+}

--- a/FrontEnd/src/pages/OAuthCallbackPage.jsx
+++ b/FrontEnd/src/pages/OAuthCallbackPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../util/AuthContext";
+import TranslatedText from "../api/TranslatedText.jsx";
 
 export default function OAuthCallbackPage() {
   const navigate = useNavigate();
@@ -21,7 +22,9 @@ export default function OAuthCallbackPage() {
 
   return (
     <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh" }}>
-      <p>로그인 처리 중...</p>
+      <p>
+        <TranslatedText text="로그인 처리 중..." />
+      </p>
     </div>
   );
 }

--- a/FrontEnd/src/util/LanguageContext.jsx
+++ b/FrontEnd/src/util/LanguageContext.jsx
@@ -1,9 +1,10 @@
 import { createContext, useContext, useState } from "react";
+import { DEFAULT_UI_LANGUAGE } from "../constants/uiLanguage.js";
 
 const LanguageContext = createContext();
 
 export const LanguageProvider = ({ children }) => {
-  const [language, setLanguage] = useState("ko");
+  const [language, setLanguage] = useState(DEFAULT_UI_LANGUAGE);
   // console.log(language);
 
   return (


### PR DESCRIPTION
## 요약

헤더 언어 드롭다운(`LanguageContext`)과 맞추기 위해, 메뉴·라벨·안내 문구 등 **UI 문자열**을 하드코딩 한국어 원문 + 번역 레이어로 정리함. **기본 언어가 한국어(`ko`)일 때는 번역 API를 호출하지 않도록** 해 호출 최소화

## 동작

- **UI 언어**: 사용자가 선택한 `language`에 따라 `TranslatedText` / `fetchTranslatedText` / `useTranslatedLabel`로 표시 문자열이 갱신
- **기본 언어**: `DEFAULT_UI_LANGUAGE`(ko)와 같으면 `fetchTranslatedText`는 원문 반환, `TranslatedText`는 캐시/API 없이 원문 표시.
- **기사 본문·요약**: 이번 PR 범위의 “공통 컴포넌트” 번역과 별개이며, 원문이 영어인 기사의 콘텐츠 번역은 기존 백엔드/Gemini 등 기존 파이프라인을 따름.
- **날짜**: `toLocaleString`에 언어별 로케일만 적용(날짜 문자열 전체를 번역 API에 넣지 않음).

## 주요 변경 파일 ( 공통 관련 ) 

| 구분 | 내용 |
|------|------|
| `constants/uiLanguage.js` | `DEFAULT_UI_LANGUAGE` 정의 |
| `util/LanguageContext.jsx` | 초기값을 상수와 통일 |
| `api/fetchTranslatedText.jsx` / `api/TranslatedText.jsx` | `ko`일 때 API 생략 |
| `hooks/useTranslatedLabel.js` | aria / title / img alt 등 단일 라벨용 훅 |
| `mainPage/Pagenation.jsx` | offset 페이지네이션 접근성 문구 번역 |
| `mainPage/ExploreResultsSection.jsx` | `section` aria-label |
| `commons/header/Header.jsx` | 로고·메뉴 툴팁/aria 등 |
| `commons/footer/Footer.jsx` | 푸터 문구 |
| `chat/ChatHistoryButton.jsx` | 팝업·FAB·안내 문구, 날짜 로케일 |
| `detailsPage/Chatbot.jsx` | 구분선·에러·로그인 안내 등 |
| `detailsPage/ArticleDetail.jsx` | 이미지 alt, 요약 오류, 발행일 로케일 |
| `globe/TrendModal.jsx` | 업데이트 라벨 + 시각 로케일 |
| `pages/OAuthCallbackPage.jsx` | 로그인 처리 중 문구 |
| `intro/...` | 이미지 alt 등 |
| 기타 | `ScrapNewsCard` 제거 버튼 title 등 |

## 확인 사항

- [x] 언어를 `ko`로 둔 상태에서 불필요한 번역 API 호출이 없는지(네트워크 탭)
- [x] `en`/`ja` 등에서 헤더·푸터·페이지네이션·모달 문구가 기대대로 표시되는지

한 줄 요약 : 전역 드롭다운 언어에 맞추는 방식은 전부 공통 패턴

헤더에서 고른 전역 언어에 맞춰, 툴팁, 검색창, 네비바와 같은 접근성 문구 같은 서비스가 직접 넣은 텍스트는 그 설정에 맞게 바뀌도록 연결

다만 기사 제목·본문처럼 API에서 오는 콘텐츠는 “메뉴 번역”과 같은 레이어가 아니라, 이미 각 화면에서 쓰던 방식(번역 컴포넌트·백엔드 등)대로 가는 부분이 있기에 이번 변경사항과는 무관함 