### PR TITLE
[FEAT] 탐색 필터의  파라미터를 검색 API 쿼리로 전달하도록 수정 및 디자인 개선 

### DIFF
--- a/FrontEnd/src/api/getNewsCardAPI.js
+++ b/FrontEnd/src/api/getNewsCardAPI.js
@@ -93,9 +93,16 @@ export async function getExploreArticles({
 
 // mainPage - Search News Card //
 // response.data.data.originalText
-export async function getSearch(input) {
+/** @param {string} input 검색어
+ *  @param {{ country?: string, category?: string, date?: string }} [exploreFilters] 탐색과 동일 필터(BE /api/search 선택 파라미터) */
+export async function getSearch(input, exploreFilters = {}) {
     try {
-        const baseUrl = `${import.meta.env.VITE_APP_API}/api/search?text=${input}`;
+        const params = new URLSearchParams();
+        params.set("text", input);
+        if (exploreFilters.country) params.set("country", exploreFilters.country);
+        if (exploreFilters.category) params.set("category", exploreFilters.category);
+        if (exploreFilters.date) params.set("date", exploreFilters.date);
+        const baseUrl = `${import.meta.env.VITE_APP_API}/api/search?${params.toString()}`;
         const response = await axios.get(baseUrl);
 
         if (response.data.isSuccess === true) {

--- a/FrontEnd/src/components/mainPage/ExploreControls.module.css
+++ b/FrontEnd/src/components/mainPage/ExploreControls.module.css
@@ -1,0 +1,279 @@
+/* ── 커스텀 셀렉트 (목록 패널 완전 커스텀) ── */
+.exploreSelect {
+  position: relative;
+  width: 100%;
+}
+
+.exploreSelect__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px 10px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #2a2a2a;
+  border: 1.5px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.exploreSelect__trigger:hover {
+  border-color: rgba(201, 162, 39, 0.55);
+}
+
+.exploreSelect__trigger:focus {
+  outline: none;
+  border-color: #c9a227;
+  box-shadow: 0 0 0 3px rgba(240, 192, 64, 0.25);
+}
+
+.exploreSelect__triggerText {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.exploreSelect__chevron {
+  flex-shrink: 0;
+  color: #7a6a40;
+  transition: transform 0.2s ease;
+}
+
+.exploreSelect__chevron--open {
+  transform: rotate(180deg);
+}
+
+.exploreSelect__panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 50;
+  max-height: 240px;
+  overflow-y: auto;
+  padding: 6px;
+  margin: 0;
+  list-style: none;
+  border-radius: 14px;
+  border: 1px solid rgba(201, 162, 39, 0.28);
+  background: linear-gradient(180deg, #fff 0%, #fffdf9 100%);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.12),
+    0 0 0 1px rgba(240, 192, 64, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  animation: explorePanelIn 0.16s ease-out;
+}
+
+@keyframes explorePanelIn {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.exploreSelect__option {
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 500;
+  color: #333;
+  text-align: left;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.exploreSelect__option:hover {
+  background: rgba(240, 192, 64, 0.18);
+  color: #1a1400;
+}
+
+.exploreSelect__option--selected {
+  background: linear-gradient(135deg, rgba(255, 236, 180, 0.65) 0%, rgba(240, 192, 64, 0.28) 100%);
+  color: #3d3200;
+  font-weight: 700;
+}
+
+/* ── 커스텀 날짜 선택 ── */
+.exploreDate {
+  position: relative;
+  width: 100%;
+}
+
+.exploreDate__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px 10px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  color: #2a2a2a;
+  border: 1.5px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  background: #fff;
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.exploreDate__trigger:hover {
+  border-color: rgba(201, 162, 39, 0.55);
+}
+
+.exploreDate__trigger:focus {
+  outline: none;
+  border-color: #c9a227;
+  box-shadow: 0 0 0 3px rgba(240, 192, 64, 0.25);
+}
+
+.exploreDate__trigger--empty {
+  color: #888;
+}
+
+.exploreDate__panel {
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: calc(100% + 6px);
+  z-index: 50;
+  padding: 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(201, 162, 39, 0.28);
+  background: linear-gradient(165deg, #fff 0%, #fffdf8 50%, #faf9f4 100%);
+  box-shadow:
+    0 12px 40px rgba(0, 0, 0, 0.12),
+    0 0 0 1px rgba(240, 192, 64, 0.15);
+  animation: explorePanelIn 0.16s ease-out;
+}
+
+.exploreDate__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+  gap: 8px;
+}
+
+.exploreDate__nav {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 10px;
+  background: #fff;
+  color: #444;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.exploreDate__nav:hover {
+  background: rgba(240, 192, 64, 0.2);
+  border-color: rgba(201, 162, 39, 0.4);
+}
+
+.exploreDate__monthLabel {
+  flex: 1;
+  text-align: center;
+  font-size: 14px;
+  font-weight: 700;
+  color: #2a2210;
+  letter-spacing: -0.02em;
+}
+
+.exploreDate__clear {
+  display: block;
+  width: 100%;
+  margin-bottom: 10px;
+  padding: 6px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #8a6a2a;
+  border: 1px dashed rgba(201, 162, 39, 0.45);
+  border-radius: 10px;
+  background: rgba(255, 248, 220, 0.4);
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.exploreDate__clear:hover {
+  background: rgba(240, 192, 64, 0.2);
+}
+
+.exploreDate__weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 2px;
+  margin-bottom: 4px;
+}
+
+.exploreDate__weekday {
+  text-align: center;
+  font-size: 10px;
+  font-weight: 700;
+  color: #999;
+  padding: 4px 0;
+}
+
+.exploreDate__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 3px;
+}
+
+.exploreDate__pad {
+  min-height: 34px;
+}
+
+.exploreDate__day {
+  min-height: 34px;
+  padding: 0;
+  font-size: 12px;
+  font-weight: 600;
+  color: #333;
+  border: none;
+  border-radius: 10px;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+
+.exploreDate__day:hover:not(:disabled) {
+  background: rgba(240, 192, 64, 0.25);
+}
+
+.exploreDate__day--today {
+  box-shadow: inset 0 0 0 1.5px rgba(201, 162, 39, 0.55);
+  color: #6b5200;
+}
+
+.exploreDate__day--selected {
+  background: linear-gradient(145deg, #e8c547 0%, #c9a227 100%);
+  color: #fff;
+  box-shadow: 0 2px 8px rgba(201, 162, 39, 0.35);
+}
+
+.exploreDate__day--selected:hover {
+  background: linear-gradient(145deg, #d4b23d 0%, #b89220 100%);
+  color: #fff;
+}

--- a/FrontEnd/src/components/mainPage/ExploreDatePicker.jsx
+++ b/FrontEnd/src/components/mainPage/ExploreDatePicker.jsx
@@ -1,0 +1,221 @@
+import { useState, useEffect, useRef, useMemo } from "react";
+import PropTypes from "prop-types";
+import { ChevronLeft, ChevronRight, Calendar } from "lucide-react";
+import styles from "./ExploreControls.module.css";
+
+const WEEKDAYS_KO = ["일", "월", "화", "수", "목", "금", "토"];
+
+function pad(n) {
+  return String(n).padStart(2, "0");
+}
+
+/** @param {Date} d */
+function toYMD(d) {
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+}
+
+/** @param {string} s yyyy-MM-dd */
+function parseYMD(s) {
+  if (!s) return null;
+  const p = s.split("-").map(Number);
+  if (p.length !== 3 || p.some(Number.isNaN)) return null;
+  const [y, m, day] = p;
+  const d = new Date(y, m - 1, day);
+  if (
+    d.getFullYear() !== y ||
+    d.getMonth() !== m - 1 ||
+    d.getDate() !== day
+  ) {
+    return null;
+  }
+  return d;
+}
+
+export default function ExploreDatePicker({
+  id,
+  value,
+  onChange,
+  placeholder,
+  clearLabel,
+  ariaLabel,
+  prevMonthAria = "이전 달",
+  nextMonthAria = "다음 달",
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef(null);
+
+  const selectedDate = useMemo(() => parseYMD(value), [value]);
+
+  const [view, setView] = useState(() => {
+    const base = selectedDate ?? new Date();
+    return new Date(base.getFullYear(), base.getMonth(), 1);
+  });
+
+  useEffect(() => {
+    if (selectedDate) {
+      setView(new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1));
+    }
+  }, [value]);
+
+  const displayText = selectedDate
+    ? selectedDate.toLocaleDateString("ko-KR", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : placeholder;
+
+  const year = view.getFullYear();
+  const month = view.getMonth();
+  const monthLabel = view.toLocaleDateString("ko-KR", {
+    year: "numeric",
+    month: "long",
+  });
+
+  const { cells } = useMemo(() => {
+    const firstDow = new Date(year, month, 1).getDay();
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const list = [];
+    for (let i = 0; i < firstDow; i += 1) {
+      list.push({ kind: "pad" });
+    }
+    for (let d = 1; d <= daysInMonth; d += 1) {
+      list.push({ kind: "day", day: d });
+    }
+    return { cells: list };
+  }, [year, month]);
+
+  const today = new Date();
+  const todayYMD = toYMD(today);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleDown(e) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleDown);
+    return () => document.removeEventListener("mousedown", handleDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  function prevMonth() {
+    setView(new Date(year, month - 1, 1));
+  }
+
+  function nextMonth() {
+    setView(new Date(year, month + 1, 1));
+  }
+
+  function selectDay(day) {
+    const d = new Date(year, month, day);
+    onChange(toYMD(d));
+    setOpen(false);
+  }
+
+  function clearDate() {
+    onChange("");
+    setOpen(false);
+  }
+
+  return (
+    <div className={styles.exploreDate} ref={wrapRef}>
+      <button
+        type="button"
+        id={id}
+        className={`${styles.exploreDate__trigger} ${!value ? styles["exploreDate__trigger--empty"] : ""}`}
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span>{displayText}</span>
+        <Calendar size={18} strokeWidth={2} aria-hidden />
+      </button>
+      {open && (
+        <div className={styles.exploreDate__panel}>
+          {value ? (
+            <button
+              type="button"
+              className={styles.exploreDate__clear}
+              onClick={clearDate}
+            >
+              {clearLabel}
+            </button>
+          ) : null}
+          <div className={styles.exploreDate__header}>
+            <button
+              type="button"
+              className={styles.exploreDate__nav}
+              onClick={prevMonth}
+              aria-label={prevMonthAria}
+            >
+              <ChevronLeft size={18} />
+            </button>
+            <span className={styles.exploreDate__monthLabel}>{monthLabel}</span>
+            <button
+              type="button"
+              className={styles.exploreDate__nav}
+              onClick={nextMonth}
+              aria-label={nextMonthAria}
+            >
+              <ChevronRight size={18} />
+            </button>
+          </div>
+          <div className={styles.exploreDate__weekdays}>
+            {WEEKDAYS_KO.map((w) => (
+              <div key={w} className={styles.exploreDate__weekday}>
+                {w}
+              </div>
+            ))}
+          </div>
+          <div className={styles.exploreDate__grid}>
+            {cells.map((cell, idx) => {
+              if (cell.kind === "pad") {
+                return (
+                  <div
+                    key={`pad-${idx}`}
+                    className={styles.exploreDate__pad}
+                  />
+                );
+              }
+              const d = new Date(year, month, cell.day);
+              const ymd = toYMD(d);
+              const isToday = ymd === todayYMD;
+              const isSelected = value === ymd;
+              return (
+                <button
+                  key={ymd}
+                  type="button"
+                  className={`${styles.exploreDate__day} ${isToday ? styles["exploreDate__day--today"] : ""} ${isSelected ? styles["exploreDate__day--selected"] : ""}`}
+                  onClick={() => selectDay(cell.day)}
+                >
+                  {cell.day}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+ExploreDatePicker.propTypes = {
+  id: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string.isRequired,
+  clearLabel: PropTypes.string.isRequired,
+  ariaLabel: PropTypes.string,
+  prevMonthAria: PropTypes.string,
+  nextMonthAria: PropTypes.string,
+};

--- a/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
+++ b/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
@@ -1,5 +1,5 @@
 import styled from "./News.module.css";
-import BasicNewsCard from "../newsCard/BasicNewsCard";
+import ExploreNewsCard from "../newsCard/ExploreNewsCard";
 import CursorPagination from "./CursorPagination";
 import TranslatedText from "../../api/TranslatedText";
 import PropTypes from "prop-types";
@@ -23,7 +23,12 @@ export default function ExploreResultsSection({
             <TranslatedText text="탐색 결과" />
           </h2>
           <p className={styled["ExploreSection__subtitle"]}>
-            <TranslatedText text="국가·카테고리·날짜 조건으로 모은 기사입니다. 키워드는 상단 검색으로 이용해 주세요." />
+            <span className={styled["ExploreSection__subtitleLine"]}>
+              <TranslatedText text="국가·카테고리·날짜 필터링 이후의 뉴스입니다." />
+            </span>
+            <span className={styled["ExploreSection__subtitleLine"]}>
+              <TranslatedText text="필터링 이후의 추가적인 검색어 기반 탐색은 상단의 검색 기능을 이용해 주세요." />
+            </span>
           </p>
         </div>
         {onDismiss && (
@@ -49,7 +54,7 @@ export default function ExploreResultsSection({
         <>
           <div className={styled["ExploreSection__grid"]}>
             {articles.map((news) => (
-              <BasicNewsCard
+              <ExploreNewsCard
                 key={news.id}
                 id={news.id}
                 press={news.sourceName}

--- a/FrontEnd/src/components/mainPage/ExploreSelect.jsx
+++ b/FrontEnd/src/components/mainPage/ExploreSelect.jsx
@@ -1,0 +1,95 @@
+import { useState, useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+import { ChevronDown } from "lucide-react";
+import styles from "./ExploreControls.module.css";
+
+export default function ExploreSelect({
+  id,
+  value,
+  onChange,
+  options,
+  ariaLabel,
+}) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef(null);
+
+  const selected = options.find((o) => o.value === value);
+  const selectedLabel = selected?.label ?? "";
+
+  useEffect(() => {
+    if (!open) return;
+    function handleDown(e) {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleDown);
+    return () => document.removeEventListener("mousedown", handleDown);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  return (
+    <div className={styles.exploreSelect} ref={wrapRef}>
+      <button
+        type="button"
+        id={id}
+        className={styles.exploreSelect__trigger}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={ariaLabel}
+        onClick={() => setOpen((o) => !o)}
+      >
+        <span className={styles.exploreSelect__triggerText}>
+          {selectedLabel}
+        </span>
+        <ChevronDown
+          size={18}
+          strokeWidth={2.25}
+          className={`${styles.exploreSelect__chevron} ${open ? styles["exploreSelect__chevron--open"] : ""}`}
+          aria-hidden
+        />
+      </button>
+      {open && (
+        <ul className={styles.exploreSelect__panel} role="listbox">
+          {options.map((o) => (
+            <li key={o.value === "" ? "__empty" : o.value} role="none">
+              <button
+                type="button"
+                role="option"
+                className={`${styles.exploreSelect__option} ${value === o.value ? styles["exploreSelect__option--selected"] : ""}`}
+                aria-selected={value === o.value}
+                onClick={() => {
+                  onChange(o.value);
+                  setOpen(false);
+                }}
+              >
+                {o.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+ExploreSelect.propTypes = {
+  id: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  ariaLabel: PropTypes.string,
+};

--- a/FrontEnd/src/components/mainPage/News.module.css
+++ b/FrontEnd/src/components/mainPage/News.module.css
@@ -150,7 +150,15 @@
     font-weight: 500;
     color: #6b6b6b;
     line-height: 1.45;
-    max-width: 52ch;
+    max-width: 100%;
+    word-break: keep-all;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.ExploreSection__subtitleLine {
+    display: block;
 }
 
 .ExploreSection__dismiss {
@@ -177,20 +185,23 @@
 
 .ExploreSection__grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 10px;
+    grid-template-columns: 1fr;
+    gap: 20px;
     align-items: start;
+    padding: 8px 4px 0;
 }
 
-@media (max-width: 900px) {
+@media (min-width: 640px) {
     .ExploreSection__grid {
-        grid-template-columns: repeat(2, 1fr);
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 24px 28px;
     }
 }
 
-@media (max-width: 480px) {
+@media (min-width: 1280px) {
     .ExploreSection__grid {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 28px 32px;
     }
 }
 

--- a/FrontEnd/src/components/mainPage/SearchContainer.jsx
+++ b/FrontEnd/src/components/mainPage/SearchContainer.jsx
@@ -1,6 +1,6 @@
 import styled from "./SearchContainer.module.css";
 import PropTypes from "prop-types";
-import { Search, SlidersHorizontal } from "lucide-react";
+import { Search, SlidersHorizontal, X } from "lucide-react";
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
@@ -9,6 +9,8 @@ import {
   EXPLORE_COUNTRY_OPTIONS,
   EXPLORE_CATEGORY_OPTIONS,
 } from "./exploreOptions";
+import ExploreSelect from "./ExploreSelect.jsx";
+import ExploreDatePicker from "./ExploreDatePicker.jsx";
 
 const EXPLORE_UI_KEYS = {
   hint: "키워드는 위 입력 후 검색 버튼을 누르세요. 여기서는 국가·카테고리·날짜로 목록만 좁힙니다.",
@@ -22,6 +24,12 @@ const EXPLORE_UI_KEYS = {
   triggerAria:
     "탐색 조건 열기. 국가, 카테고리, 날짜로 목록을 좁힐 수 있습니다.",
   dialogAria: "탐색 조건",
+  chipsHint: "적용 중인 조건",
+  removeChip: "제거",
+  datePlaceholder: "날짜를 선택하세요",
+  dateClear: "날짜 지우기",
+  datePrevMonth: "이전 달",
+  dateNextMonth: "다음 달",
 };
 
 export default function SearchContainer({
@@ -177,6 +185,46 @@ export default function SearchContainer({
     [exUi.all],
   );
 
+  const exploreChips = useMemo(() => {
+    if (!showExplore || !hasExploreFilters) return [];
+    const chips = [];
+    if (exCountry) {
+      const opt = countryOptions.find((o) => o.value === exCountry);
+      chips.push({
+        key: "country",
+        text: opt?.label ?? exCountry,
+      });
+    }
+    if (exCategory) {
+      const opt = categoryOptions.find((o) => o.value === exCategory);
+      chips.push({
+        key: "category",
+        text: opt?.label ?? exCategory,
+      });
+    }
+    if (exDate) {
+      chips.push({
+        key: "date",
+        text: exDate.replace(/-/g, "."),
+      });
+    }
+    return chips;
+  }, [
+    showExplore,
+    hasExploreFilters,
+    exCountry,
+    exCategory,
+    exDate,
+    countryOptions,
+    categoryOptions,
+  ]);
+
+  function removeExploreChip(key) {
+    if (key === "country") setExCountry("");
+    else if (key === "category") setExCategory("");
+    else if (key === "date") setExDate("");
+  }
+
   return (
     <div className={styled["searchContainer--container"]}>
       <div
@@ -248,6 +296,34 @@ export default function SearchContainer({
           </button>
         </div>
 
+        {showExplore && exploreChips.length > 0 && (
+          <div
+            className={styled["searchExplore__chipsRow"]}
+            aria-label={exUi.chipsHint}
+          >
+            <span className={styled["searchExplore__chipsHint"]}>
+              {exUi.chipsHint}
+            </span>
+            <div className={styled["searchExplore__chips"]}>
+              {exploreChips.map((chip) => (
+                <span key={chip.key} className={styled["searchExplore__chip"]}>
+                  <span className={styled["searchExplore__chipText"]}>
+                    {chip.text}
+                  </span>
+                  <button
+                    type="button"
+                    className={styled["searchExplore__chipRemove"]}
+                    onClick={() => removeExploreChip(chip.key)}
+                    aria-label={`${chip.text} ${exUi.removeChip}`}
+                  >
+                    <X size={12} strokeWidth={2.5} aria-hidden />
+                  </button>
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
         {showExplore && exploreOpen && (
           <div
             className={styled["searchExplore__popover"]}
@@ -259,39 +335,35 @@ export default function SearchContainer({
             <div className={styled["searchExplore__grid"]}>
               <div className={styled["searchExplore__field"]}>
                 <label htmlFor="explore-country">{exUi.labelCountry}</label>
-                <select
+                <ExploreSelect
                   id="explore-country"
                   value={exCountry}
-                  onChange={(e) => setExCountry(e.target.value)}
-                >
-                  {countryOptions.map((o) => (
-                    <option key={o.value || "all"} value={o.value}>
-                      {o.label}
-                    </option>
-                  ))}
-                </select>
+                  onChange={setExCountry}
+                  options={countryOptions}
+                  ariaLabel={exUi.labelCountry}
+                />
               </div>
               <div className={styled["searchExplore__field"]}>
                 <label htmlFor="explore-category">{exUi.labelCategory}</label>
-                <select
+                <ExploreSelect
                   id="explore-category"
                   value={exCategory}
-                  onChange={(e) => setExCategory(e.target.value)}
-                >
-                  {categoryOptions.map((o) => (
-                    <option key={o.value || "all-c"} value={o.value}>
-                      {o.label}
-                    </option>
-                  ))}
-                </select>
+                  onChange={setExCategory}
+                  options={categoryOptions}
+                  ariaLabel={exUi.labelCategory}
+                />
               </div>
               <div className={styled["searchExplore__field"]}>
                 <label htmlFor="explore-date">{exUi.labelDate}</label>
-                <input
+                <ExploreDatePicker
                   id="explore-date"
-                  type="date"
                   value={exDate}
-                  onChange={(e) => setExDate(e.target.value)}
+                  onChange={setExDate}
+                  placeholder={exUi.datePlaceholder}
+                  clearLabel={exUi.dateClear}
+                  ariaLabel={exUi.labelDate}
+                  prevMonthAria={exUi.datePrevMonth}
+                  nextMonthAria={exUi.dateNextMonth}
                 />
               </div>
             </div>

--- a/FrontEnd/src/components/mainPage/SearchContainer.jsx
+++ b/FrontEnd/src/components/mainPage/SearchContainer.jsx
@@ -2,7 +2,7 @@ import styled from "./SearchContainer.module.css";
 import PropTypes from "prop-types";
 import { Search, SlidersHorizontal } from "lucide-react";
 import { useState, useEffect, useRef, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import {
@@ -30,6 +30,7 @@ export default function SearchContainer({
   onExploreApply,
 }) {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const { language } = useLanguage();
   const exploreWrapRef = useRef(null);
 
@@ -104,7 +105,21 @@ export default function SearchContainer({
   function handleSearch() {
     const keyword = inputSearchTerm.trim();
     if (!keyword) return;
-    navigate(`/search/${keyword}`);
+    const params = new URLSearchParams();
+    if (showExplore) {
+      if (exCountry) params.set("country", exCountry);
+      if (exCategory) params.set("category", exCategory);
+      if (exDate) params.set("date", exDate);
+    } else {
+      ["country", "category", "date"].forEach((key) => {
+        const v = searchParams.get(key);
+        if (v) params.set(key, v);
+      });
+    }
+    const qs = params.toString();
+    navigate(
+      `/search/${encodeURIComponent(keyword)}${qs ? `?${qs}` : ""}`,
+    );
   }
 
   function handleInputChange(event) {

--- a/FrontEnd/src/components/mainPage/SearchContainer.module.css
+++ b/FrontEnd/src/components/mainPage/SearchContainer.module.css
@@ -244,15 +244,19 @@
 }
 
 .searchExplore__popover {
+    position: relative;
+    z-index: 20;
     margin-top: 10px;
-    padding: 14px 16px 16px;
-    border-radius: 12px;
-    border: 1px solid rgba(0, 0, 0, 0.08);
-    background: #fff;
+    padding: 16px 18px 18px;
+    border-radius: 16px;
+    border: 1px solid rgba(201, 162, 39, 0.2);
+    background: linear-gradient(165deg, #fff 0%, #fffdf8 45%, #faf9f6 100%);
     box-shadow:
-        0 4px 24px rgba(0, 0, 0, 0.1),
-        0 0 0 1px rgba(240, 192, 64, 0.12);
+        0 8px 32px rgba(0, 0, 0, 0.08),
+        0 0 0 1px rgba(240, 192, 64, 0.15),
+        inset 0 1px 0 rgba(255, 255, 255, 0.95);
     animation: searchExplorePopoverIn 0.18s ease-out;
+    overflow: visible;
 }
 
 @keyframes searchExplorePopoverIn {
@@ -283,20 +287,82 @@
 .searchExplore__field label {
     display: block;
     font-size: 11px;
-    font-weight: 600;
-    color: #555;
-    margin-bottom: 4px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: #4a4a4a;
+    margin-bottom: 6px;
 }
 
-.searchExplore__field select,
-.searchExplore__field input[type="date"] {
+/* ── 적용 중인 탐색 조건 칩 (검색창 아래) ── */
+.searchExplore__chipsRow {
     width: 100%;
-    padding: 8px 10px;
-    font-size: 13px;
-    border: 1px solid #ccc;
-    border-radius: 6px;
-    box-sizing: border-box;
-    background: #fff;
+    margin-top: 10px;
+    padding: 8px 2px 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px 10px;
+}
+
+.searchExplore__chipsHint {
+    font-size: 11px;
+    font-weight: 700;
+    color: #888;
+    letter-spacing: -0.02em;
+}
+
+.searchExplore__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+}
+
+.searchExplore__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    max-width: 100%;
+    padding: 4px 4px 4px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    color: #5c4a12;
+    background: linear-gradient(135deg, rgba(255, 248, 220, 0.95) 0%, rgba(255, 237, 180, 0.65) 100%);
+    border: 1px solid rgba(201, 162, 39, 0.45);
+    border-radius: 999px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.searchExplore__chipText {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: min(200px, 42vw);
+}
+
+.searchExplore__chipRemove {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 22px;
+    padding: 0;
+    border: none;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.06);
+    color: #666;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease, transform 0.12s ease;
+}
+
+.searchExplore__chipRemove:hover {
+    background: rgba(180, 60, 60, 0.15);
+    color: #a33;
+}
+
+.searchExplore__chipRemove:active {
+    transform: scale(0.94);
 }
 
 .searchExplore__actions {

--- a/FrontEnd/src/components/newsCard/ExploreNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/ExploreNewsCard.jsx
@@ -1,0 +1,75 @@
+import styled from "./ExploreNewsCard.module.css";
+import PropTypes from "prop-types";
+import { useNavigate } from "react-router-dom";
+import TranslatedText from "../../api/TranslatedText";
+import { Compass } from "lucide-react";
+
+export default function ExploreNewsCard({
+  id,
+  press,
+  title,
+  summary,
+  image,
+  year,
+  month,
+  day,
+}) {
+  const navigate = useNavigate();
+
+  function handleClick() {
+    navigate(`/detail/${id}`);
+  }
+
+  return (
+    <div
+      className={styled.exploreCard}
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      <div className={styled.exploreCard__inner}>
+        <div>
+          <span className={styled.exploreCard__badge}>
+            <Compass size={11} strokeWidth={2.5} aria-hidden />
+            <TranslatedText text="탐색" />
+          </span>
+          <p className={styled.exploreCard__press}>{press}</p>
+          <p className={styled.exploreCard__title}>
+            <TranslatedText text={title} />
+          </p>
+          <p className={styled.exploreCard__preview}>
+            <TranslatedText text={summary} />
+          </p>
+        </div>
+        <p className={styled.exploreCard__date}>
+          {year}.{month}.{day}
+        </p>
+      </div>
+      <div className={styled.exploreCard__imageCol}>
+        <div className={styled.exploreCard__imageFrame}>
+          <div
+            className={styled.exploreCard__image}
+            style={image ? { backgroundImage: `url(${image})` } : {}}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ExploreNewsCard.propTypes = {
+  id: PropTypes.number.isRequired,
+  press: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  summary: PropTypes.string.isRequired,
+  image: PropTypes.string.isRequired,
+  year: PropTypes.string.isRequired,
+  month: PropTypes.string.isRequired,
+  day: PropTypes.string.isRequired,
+};

--- a/FrontEnd/src/components/newsCard/ExploreNewsCard.module.css
+++ b/FrontEnd/src/components/newsCard/ExploreNewsCard.module.css
@@ -1,0 +1,142 @@
+/* 탐색 결과 전용 — 최신 뉴스 Basic 카드와 시각적 구분 */
+.exploreCard {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  width: 100%;
+  min-height: 118px;
+  position: relative;
+  overflow: hidden;
+  cursor: pointer;
+  border-radius: 14px;
+  border: 1px solid rgba(201, 162, 39, 0.22);
+  background: linear-gradient(135deg, #fffdf9 0%, #faf8f4 50%, #fff 100%);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+  transition:
+    border-color 0.25s ease,
+    box-shadow 0.25s ease,
+    transform 0.2s ease;
+}
+
+.exploreCard::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  background: linear-gradient(180deg, #e8c547 0%, #c9a227 50%, #a67c00 100%);
+  border-radius: 14px 0 0 14px;
+}
+
+.exploreCard:hover {
+  border-color: rgba(201, 162, 39, 0.45);
+  box-shadow:
+    0 6px 20px rgba(201, 162, 39, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.06);
+  transform: translateY(-2px);
+}
+
+.exploreCard__inner {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  padding: 10px 12px 10px 14px;
+}
+
+.exploreCard__badge {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 4px;
+  padding: 2px 8px;
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #7a5f12;
+  background: rgba(240, 192, 64, 0.2);
+  border: 1px solid rgba(201, 162, 39, 0.35);
+  border-radius: 999px;
+}
+
+.exploreCard__press {
+  margin: 0;
+  font-size: 9px;
+  font-weight: 700;
+  color: #888;
+  letter-spacing: 0.02em;
+}
+
+.exploreCard__title {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.35;
+  color: #1a1a1a;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+.exploreCard:hover .exploreCard__title {
+  color: #6b5200;
+}
+
+.exploreCard__preview {
+  margin: 4px 0 0;
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.4;
+  color: #555;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: break-word;
+}
+
+.exploreCard__date {
+  margin: 6px 0 0;
+  font-size: 10px;
+  font-weight: 500;
+  color: #999;
+}
+
+.exploreCard__imageCol {
+  width: 108px;
+  flex-shrink: 0;
+  padding: 8px 10px 8px 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.exploreCard__imageFrame {
+  width: 100%;
+  height: 92px;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 2px solid rgba(255, 255, 255, 0.95);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.08);
+}
+
+.exploreCard__image {
+  width: 100%;
+  height: 100%;
+  background-size: cover;
+  background-position: center;
+  background-image: linear-gradient(145deg, #e8e4dc 0%, #f5f2eb 100%);
+  transition: transform 0.35s ease;
+}
+
+.exploreCard:hover .exploreCard__image {
+  transform: scale(1.06);
+}

--- a/FrontEnd/src/pages/SearchPage.jsx
+++ b/FrontEnd/src/pages/SearchPage.jsx
@@ -3,13 +3,25 @@ import SearchContainer from '../components/mainPage/SearchContainer';
 import SearchNews from '../components/mainPage/SearchNews';
 import BlankNews from '../components/mainPage/BlankNews';
 
-import { useState, useEffect } from 'react';
-import { useParams, useLocation } from "react-router-dom";
+import { useState, useEffect, useCallback } from 'react';
+import { useParams, useLocation, useSearchParams } from "react-router-dom";
 import { getSearch } from '../api/getNewsCardAPI';
+
+function exploreFiltersFromParams(searchParams) {
+    const country = searchParams.get("country");
+    const category = searchParams.get("category");
+    const date = searchParams.get("date");
+    return {
+        ...(country ? { country } : {}),
+        ...(category ? { category } : {}),
+        ...(date ? { date } : {}),
+    };
+}
 
 export default function SearchPage() {
     const { keyword } = useParams();
     const location = useLocation();
+    const [searchParams] = useSearchParams();
     const [searchTerm, setSearchTerm] = useState(keyword);
     
     const [searchResults, setSearchResults] = useState(null);
@@ -17,24 +29,26 @@ export default function SearchPage() {
     const [originalWord, setOriginalWord] = useState("");
     const [isLoading, setIsLoading] = useState(false);
 
-    const handleSearch = async (term) => {
-        if (!term.trim()) return; // 빈 값이면 검색 안 함
-        setIsLoading(true); // 로딩 시작
+    const handleSearch = useCallback(async (term, exploreFilters = {}) => {
+        if (!term.trim()) return;
+        setIsLoading(true);
 
-        const { results, originalText, translatedText } = await getSearch(term);
+        const { results, originalText, translatedText } = await getSearch(term, exploreFilters);
         setSearchResults(results || []);
         setOriginalWord(originalText || "");
         setTranslatedWord(translatedText || "");
 
-        setIsLoading(false); // 로딩 끝
-    };
+        setIsLoading(false);
+    }, []);
+
+    const exploreQueryKey = searchParams.toString();
 
     useEffect(() => {
-        if (keyword) {
-            setSearchTerm(keyword);
-            handleSearch(keyword);
-        }
-    }, [location.key]);
+        if (!keyword) return;
+        setSearchTerm(keyword);
+        const filters = exploreFiltersFromParams(searchParams);
+        handleSearch(keyword, filters);
+    }, [location.key, keyword, exploreQueryKey, handleSearch]);
 
 
     return(


### PR DESCRIPTION
## 요약

메인 탐색(Explore) 흐름의 UI를 다듬고, 백엔드 `GET /api/search`의 선택 필터(`country`, `category`, `date`)를 
프론트에서 넘기도록 연결, 탐색 이후의 각 컴포넌트 디자인 개선.

## 변경 사항

### 검색 · 탐색 연동
- `getSearch`: `URLSearchParams`로 `text` + 탐색 필터 선택 전달
- `SearchContainer`: 탐색 조건을 검색 이동 URL 쿼리에 반영, 검색 페이지에서 쿼리 유지
- `SearchPage`: `useSearchParams`로 필터 파싱 후 `getSearch` 호출

### 탐색 패널
- `ExploreSelect` / `ExploreDatePicker`: 네이티브 드롭다운·날짜 입력 대신 커스텀 UI (`ExploreControls.module.css`)
- 탐색 조건 (적용 중인 조건, 개별 제거)
- `EXPLORE_UI_KEYS`에 날짜 플레이스홀더·지우기·달 네비 등 문구 추가(번역 배치 포함)

### 탐색 결과 영역
- `ExploreNewsCard`: 최신 뉴스 `BasicNewsCard`와 구분되는 스타일
- `ExploreResultsSection`: 부제를 두 문장으로 분리, 줄 간격·`word-break` 조정
- 탐색 결과 그리드: 열·`gap` 조정(2열 중심, 넓은 화면에서 3열)

### 스타일
- `SearchContainer.module.css`: 탐색 팝오버·칩 등 (기존 네이티브 select/date 스타일 제거)

## 확인 방법
- [x] 메인에서 탐색 조건 설정 → 검색 시 URL에 쿼리 포함·API 요청 확인
- [x] 탐색 패널 셀렉트·달력 UI·칩 동작
- [x] 탐색 결과 카드·그리드·부제 레이아웃