### PR TITLE
[FEAT]: 비 로그인 상태 기사 Context 유지하도록 수정(Redis 익명세션)

### DIFF
--- a/FrontEnd/src/api/chatAPI.js
+++ b/FrontEnd/src/api/chatAPI.js
@@ -1,4 +1,21 @@
+import axios from "axios";
 import { authAPI } from "./authAPI";
+
+const apiBase = () => import.meta.env.VITE_APP_API ?? "";
+
+// 비로그인: Redis에 저장된 기사별 대화 (백엔드 GET /api/ai/{id}/ask/history)
+export const getAnonymousChatsByArticle = async (articleId, sessionId) => {
+    if (!sessionId || !articleId) return [];
+    try {
+        const response = await axios.get(`${apiBase()}/api/ai/${articleId}/ask/history`, {
+            params: { anonymousSession: sessionId },
+        });
+        return response.data?.data ?? [];
+    } catch (error) {
+        console.error("비로그인 채팅 히스토리 조회 실패:", error);
+        return [];
+    }
+};
 
 // 기사별 전체 대화 내역 (상세 페이지 챗봇)
 export const getChatsByArticle = async (articleId) => {

--- a/FrontEnd/src/api/detailsAPI.js
+++ b/FrontEnd/src/api/detailsAPI.js
@@ -20,11 +20,22 @@ export const getNewsDetailsSummary = async (articleId) => {
     }
 };
 
-export const getNewsDetailsAsk = (articleId, question, onMessage, onComplete, onError, token = null) => {
-    let url = `${import.meta.env.VITE_APP_API}/api/ai/${articleId}/ask?question=${encodeURIComponent(question)}`;
-    // EventSource는 커스텀 헤더 미지원 → 로그인 시 쿼리 파라미터로 토큰 전달 (BE 인증 + 히스토리 저장)
+export const getNewsDetailsAsk = (
+    articleId,
+    question,
+    onMessage,
+    onComplete,
+    onError,
+    token = null,
+    anonymousSessionId = null
+) => {
+    const base = import.meta.env.VITE_APP_API ?? "";
+    let url = `${base}/api/ai/${articleId}/ask?question=${encodeURIComponent(question)}`;
+    // EventSource는 커스텀 헤더 미지원 → 로그인: token, 비로그인: anonymousSession (BE Redis 맥락)
     if (token) {
         url += `&token=${encodeURIComponent(token)}`;
+    } else if (anonymousSessionId) {
+        url += `&anonymousSession=${encodeURIComponent(anonymousSessionId)}`;
     }
 
     const eventSource = new EventSource(url);

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -3,11 +3,12 @@ import styles from "./Chatbot.module.css";
 import { Send } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { getNewsDetailsAsk } from "../../api/detailsAPI.js";
-import { getChatsByArticle } from "../../api/chatAPI.js";
+import { getAnonymousChatsByArticle, getChatsByArticle } from "../../api/chatAPI.js";
 
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import { useAuth } from "../../util/AuthContext.jsx";
+import { getOrCreateAnonymousSessionId } from "../../util/anonymousSession.js";
 
 export default function Chatbot({ articleId }) {
     const [input, setInput] = useState("");
@@ -32,7 +33,24 @@ export default function Chatbot({ articleId }) {
             if (token && articleId) {
                 const history = await getChatsByArticle(articleId);
                 if (history.length > 0) {
-                    // 이전 대화 내역을 messages로 변환
+                    const historyMessages = [];
+                    history.forEach((chat) => {
+                        historyMessages.push({ type: "user", text: chat.question });
+                        historyMessages.push({ type: "bot", text: chat.answer });
+                    });
+                    setMessages([
+                        { type: "bot", text: translatedGreeting },
+                        { type: "divider", text: "── 이전 대화 내역 ──" },
+                        ...historyMessages,
+                        { type: "divider", text: "── 새 대화 ──" },
+                    ]);
+                } else {
+                    setMessages([{ type: "bot", text: translatedGreeting }]);
+                }
+            } else if (articleId) {
+                const sessionId = getOrCreateAnonymousSessionId();
+                const history = sessionId ? await getAnonymousChatsByArticle(articleId, sessionId) : [];
+                if (history.length > 0) {
                     const historyMessages = [];
                     history.forEach((chat) => {
                         historyMessages.push({ type: "user", text: chat.question });
@@ -71,6 +89,8 @@ export default function Chatbot({ articleId }) {
         setInput("");
         setIsStreaming(true);
 
+        const anonymousSessionId = token ? null : getOrCreateAnonymousSessionId();
+
         const close = getNewsDetailsAsk(
             articleId,
             userText,
@@ -98,7 +118,8 @@ export default function Chatbot({ articleId }) {
                     return updated;
                 });
             },
-            token
+            token,
+            anonymousSessionId
         );
 
         closeEventSourceRef.current = close;
@@ -113,7 +134,7 @@ export default function Chatbot({ articleId }) {
             <div className={styles.chatHeader}>Global AI</div>
             {!token && (
                 <div className={styles.loginNotice}>
-                    💡 로그인하면 대화 내역이 저장되고 문맥이 이어집니다.
+                    💡 이 브라우저에서는 잠시 대화가 유지됩니다. 로그인하면 계정에 저장됩니다.
                 </div>
             )}
             <div className={styles.chatBody} ref={chatRef}>

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -8,6 +8,7 @@ import {
   getChatsByArticle,
 } from "../../api/chatAPI.js";
 
+import TranslatedText from "../../api/TranslatedText.jsx";
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import { useAuth } from "../../util/AuthContext.jsx";
@@ -17,7 +18,6 @@ export default function Chatbot({ articleId }) {
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState([]);
   const [isStreaming, setIsStreaming] = useState(false);
-  const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
   const chatRef = useRef(null);
   const closeEventSourceRef = useRef(null);
 
@@ -26,7 +26,7 @@ export default function Chatbot({ articleId }) {
 
   const [placeholder, setPlaceholder] = useState("질문을 입력하세요...");
 
-  // 인사말 번역 + 로그인 시 이전 대화 내역 불러오기
+  // 인사말 번역 + 로그인·비로그인 이전 대화 내역
   useEffect(() => {
     const init = async () => {
       const translatedGreeting = await fetchTranslatedText(
@@ -49,9 +49,9 @@ export default function Chatbot({ articleId }) {
           });
           setMessages([
             { type: "bot", text: translatedGreeting },
-            { type: "divider", text: "── 이전 대화 내역 ──" },
+            { type: "divider", kind: "history" },
             ...historyMessages,
-            { type: "divider", text: "── 새 대화 ──" },
+            { type: "divider", kind: "new" },
           ]);
         } else {
           setMessages([{ type: "bot", text: translatedGreeting }]);
@@ -69,9 +69,9 @@ export default function Chatbot({ articleId }) {
           });
           setMessages([
             { type: "bot", text: translatedGreeting },
-            { type: "divider", text: "── 이전 대화 내역 ──" },
+            { type: "divider", kind: "history" },
             ...historyMessages,
-            { type: "divider", text: "── 새 대화 ──" },
+            { type: "divider", kind: "new" },
           ]);
         } else {
           setMessages([{ type: "bot", text: translatedGreeting }]);
@@ -79,7 +79,6 @@ export default function Chatbot({ articleId }) {
       } else {
         setMessages([{ type: "bot", text: translatedGreeting }]);
       }
-      setIsHistoryLoaded(true);
     };
     init();
   }, [articleId, language, token]);
@@ -126,7 +125,8 @@ export default function Chatbot({ articleId }) {
           if (updated[updated.length - 1].text === "") {
             updated[updated.length - 1] = {
               type: "bot",
-              text: "응답을 가져오는 데 실패했습니다.",
+              text: "",
+              fetchError: true,
             };
           }
           return updated;
@@ -151,8 +151,8 @@ export default function Chatbot({ articleId }) {
       <div className={styles.chatHeader}>Global AI</div>
       {!token && (
         <div className={styles.loginNotice}>
-          💡 비로그인 상태에서는 대화가 짧은 기간(7일) 동안만 일시적으로
-          유지되며, 로그인하면 계정에 영구 저장됩니다.
+          <span aria-hidden>💡 </span>
+          <TranslatedText text="비로그인 상태에서는 대화가 짧은 기간(7일) 동안만 일시적으로 유지되며, 로그인하면 계정에 영구 저장됩니다." />
         </div>
       )}
       <div className={styles.chatBody} ref={chatRef}>
@@ -160,7 +160,20 @@ export default function Chatbot({ articleId }) {
           if (msg.type === "divider") {
             return (
               <div key={index} className={styles.divider}>
-                {msg.text}
+                <TranslatedText
+                  text={
+                    msg.kind === "history"
+                      ? "── 이전 대화 내역 ──"
+                      : "── 새 대화 ──"
+                  }
+                />
+              </div>
+            );
+          }
+          if (msg.type === "bot" && msg.fetchError) {
+            return (
+              <div key={index} className={styles.botMessage}>
+                <TranslatedText text="응답을 가져오는 데 실패했습니다." />
               </div>
             );
           }
@@ -181,15 +194,17 @@ export default function Chatbot({ articleId }) {
             </div>
           );
         })}
-        {isStreaming && messages[messages.length - 1]?.text === "" && (
-          <div className={styles.botMessage}>
-            <span className={styles.typingIndicator}>
-              <span />
-              <span />
-              <span />
-            </span>
-          </div>
-        )}
+        {isStreaming &&
+          messages[messages.length - 1]?.text === "" &&
+          !messages[messages.length - 1]?.fetchError && (
+            <div className={styles.botMessage}>
+              <span className={styles.typingIndicator}>
+                <span />
+                <span />
+                <span />
+              </span>
+            </div>
+          )}
       </div>
       <div className={styles.chatInput}>
         <input

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -3,7 +3,10 @@ import styles from "./Chatbot.module.css";
 import { Send } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { getNewsDetailsAsk } from "../../api/detailsAPI.js";
-import { getAnonymousChatsByArticle, getChatsByArticle } from "../../api/chatAPI.js";
+import {
+  getAnonymousChatsByArticle,
+  getChatsByArticle,
+} from "../../api/chatAPI.js";
 
 import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
@@ -11,167 +14,196 @@ import { useAuth } from "../../util/AuthContext.jsx";
 import { getOrCreateAnonymousSessionId } from "../../util/anonymousSession.js";
 
 export default function Chatbot({ articleId }) {
-    const [input, setInput] = useState("");
-    const [messages, setMessages] = useState([]);
-    const [isStreaming, setIsStreaming] = useState(false);
-    const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
-    const chatRef = useRef(null);
-    const closeEventSourceRef = useRef(null);
+  const [input, setInput] = useState("");
+  const [messages, setMessages] = useState([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
+  const chatRef = useRef(null);
+  const closeEventSourceRef = useRef(null);
 
-    const { language } = useLanguage();
-    const { token } = useAuth();
+  const { language } = useLanguage();
+  const { token } = useAuth();
 
-    const [placeholder, setPlaceholder] = useState("질문을 입력하세요...");
+  const [placeholder, setPlaceholder] = useState("질문을 입력하세요...");
 
-    // 인사말 번역 + 로그인 시 이전 대화 내역 불러오기
-    useEffect(() => {
-        const init = async () => {
-            const translatedGreeting = await fetchTranslatedText("안녕하세요! 무엇을 도와드릴까요?", language);
-            const translatedPlaceholder = await fetchTranslatedText("질문을 입력하세요...", language);
-            setPlaceholder(translatedPlaceholder);
+  // 인사말 번역 + 로그인 시 이전 대화 내역 불러오기
+  useEffect(() => {
+    const init = async () => {
+      const translatedGreeting = await fetchTranslatedText(
+        "안녕하세요! 무엇을 도와드릴까요?",
+        language,
+      );
+      const translatedPlaceholder = await fetchTranslatedText(
+        "질문을 입력하세요...",
+        language,
+      );
+      setPlaceholder(translatedPlaceholder);
 
-            if (token && articleId) {
-                const history = await getChatsByArticle(articleId);
-                if (history.length > 0) {
-                    const historyMessages = [];
-                    history.forEach((chat) => {
-                        historyMessages.push({ type: "user", text: chat.question });
-                        historyMessages.push({ type: "bot", text: chat.answer });
-                    });
-                    setMessages([
-                        { type: "bot", text: translatedGreeting },
-                        { type: "divider", text: "── 이전 대화 내역 ──" },
-                        ...historyMessages,
-                        { type: "divider", text: "── 새 대화 ──" },
-                    ]);
-                } else {
-                    setMessages([{ type: "bot", text: translatedGreeting }]);
-                }
-            } else if (articleId) {
-                const sessionId = getOrCreateAnonymousSessionId();
-                const history = sessionId ? await getAnonymousChatsByArticle(articleId, sessionId) : [];
-                if (history.length > 0) {
-                    const historyMessages = [];
-                    history.forEach((chat) => {
-                        historyMessages.push({ type: "user", text: chat.question });
-                        historyMessages.push({ type: "bot", text: chat.answer });
-                    });
-                    setMessages([
-                        { type: "bot", text: translatedGreeting },
-                        { type: "divider", text: "── 이전 대화 내역 ──" },
-                        ...historyMessages,
-                        { type: "divider", text: "── 새 대화 ──" },
-                    ]);
-                } else {
-                    setMessages([{ type: "bot", text: translatedGreeting }]);
-                }
-            } else {
-                setMessages([{ type: "bot", text: translatedGreeting }]);
-            }
-            setIsHistoryLoaded(true);
-        };
-        init();
-    }, [articleId, language, token]);
-
-    // 언마운트 시 SSE 연결 종료
-    useEffect(() => {
-        return () => {
-            if (closeEventSourceRef.current) closeEventSourceRef.current();
-        };
-    }, []);
-
-    const handleSend = () => {
-        if (!input.trim() || isStreaming) return;
-
-        const userText = input;
-        const newMessages = [...messages, { type: "user", text: userText }];
-        setMessages([...newMessages, { type: "bot", text: "" }]);
-        setInput("");
-        setIsStreaming(true);
-
-        const anonymousSessionId = token ? null : getOrCreateAnonymousSessionId();
-
-        const close = getNewsDetailsAsk(
-            articleId,
-            userText,
-            (chunk) => {
-                setMessages((prev) => {
-                    const updated = [...prev];
-                    updated[updated.length - 1] = {
-                        ...updated[updated.length - 1],
-                        text: updated[updated.length - 1].text + chunk,
-                    };
-                    return updated;
-                });
-            },
-            () => {
-                setIsStreaming(false);
-            },
-            (error) => {
-                console.error("스트리밍 에러:", error);
-                setIsStreaming(false);
-                setMessages((prev) => {
-                    const updated = [...prev];
-                    if (updated[updated.length - 1].text === "") {
-                        updated[updated.length - 1] = { type: "bot", text: "응답을 가져오는 데 실패했습니다." };
-                    }
-                    return updated;
-                });
-            },
-            token,
-            anonymousSessionId
-        );
-
-        closeEventSourceRef.current = close;
+      if (token && articleId) {
+        const history = await getChatsByArticle(articleId);
+        if (history.length > 0) {
+          const historyMessages = [];
+          history.forEach((chat) => {
+            historyMessages.push({ type: "user", text: chat.question });
+            historyMessages.push({ type: "bot", text: chat.answer });
+          });
+          setMessages([
+            { type: "bot", text: translatedGreeting },
+            { type: "divider", text: "── 이전 대화 내역 ──" },
+            ...historyMessages,
+            { type: "divider", text: "── 새 대화 ──" },
+          ]);
+        } else {
+          setMessages([{ type: "bot", text: translatedGreeting }]);
+        }
+      } else if (articleId) {
+        const sessionId = getOrCreateAnonymousSessionId();
+        const history = sessionId
+          ? await getAnonymousChatsByArticle(articleId, sessionId)
+          : [];
+        if (history.length > 0) {
+          const historyMessages = [];
+          history.forEach((chat) => {
+            historyMessages.push({ type: "user", text: chat.question });
+            historyMessages.push({ type: "bot", text: chat.answer });
+          });
+          setMessages([
+            { type: "bot", text: translatedGreeting },
+            { type: "divider", text: "── 이전 대화 내역 ──" },
+            ...historyMessages,
+            { type: "divider", text: "── 새 대화 ──" },
+          ]);
+        } else {
+          setMessages([{ type: "bot", text: translatedGreeting }]);
+        }
+      } else {
+        setMessages([{ type: "bot", text: translatedGreeting }]);
+      }
+      setIsHistoryLoaded(true);
     };
+    init();
+  }, [articleId, language, token]);
 
-    useEffect(() => {
-        chatRef.current?.scrollTo({ top: chatRef.current.scrollHeight, behavior: "smooth" });
-    }, [messages]);
+  // 언마운트 시 SSE 연결 종료
+  useEffect(() => {
+    return () => {
+      if (closeEventSourceRef.current) closeEventSourceRef.current();
+    };
+  }, []);
 
-    return (
-        <div className={styles.chatbot}>
-            <div className={styles.chatHeader}>Global AI</div>
-            {!token && (
-                <div className={styles.loginNotice}>
-                    💡 이 브라우저에서는 잠시 대화가 유지됩니다. 로그인하면 계정에 저장됩니다.
-                </div>
-            )}
-            <div className={styles.chatBody} ref={chatRef}>
-                {messages.map((msg, index) => {
-                    if (msg.type === "divider") {
-                        return <div key={index} className={styles.divider}>{msg.text}</div>;
-                    }
-                    return (
-                        <div key={index} className={msg.type === "bot" ? styles.botMessage : styles.userMessage}>
-                            {msg.type === "bot"
-                                ? <div className={styles.markdown}><ReactMarkdown>{msg.text}</ReactMarkdown></div>
-                                : msg.text
-                            }
-                        </div>
-                    );
-                })}
-                {isStreaming && messages[messages.length - 1]?.text === "" && (
-                    <div className={styles.botMessage}>
-                        <span className={styles.typingIndicator}>
-                            <span /><span /><span />
-                        </span>
-                    </div>
-                )}
-            </div>
-            <div className={styles.chatInput}>
-                <input
-                    type="text"
-                    value={input}
-                    onChange={(e) => setInput(e.target.value)}
-                    placeholder={placeholder}
-                    disabled={isStreaming}
-                    onKeyDown={(e) => e.key === "Enter" && handleSend()}
-                />
-                <button onClick={handleSend} disabled={isStreaming}>
-                    <Send size={20} />
-                </button>
-            </div>
-        </div>
+  const handleSend = () => {
+    if (!input.trim() || isStreaming) return;
+
+    const userText = input;
+    const newMessages = [...messages, { type: "user", text: userText }];
+    setMessages([...newMessages, { type: "bot", text: "" }]);
+    setInput("");
+    setIsStreaming(true);
+
+    const anonymousSessionId = token ? null : getOrCreateAnonymousSessionId();
+
+    const close = getNewsDetailsAsk(
+      articleId,
+      userText,
+      (chunk) => {
+        setMessages((prev) => {
+          const updated = [...prev];
+          updated[updated.length - 1] = {
+            ...updated[updated.length - 1],
+            text: updated[updated.length - 1].text + chunk,
+          };
+          return updated;
+        });
+      },
+      () => {
+        setIsStreaming(false);
+      },
+      (error) => {
+        console.error("스트리밍 에러:", error);
+        setIsStreaming(false);
+        setMessages((prev) => {
+          const updated = [...prev];
+          if (updated[updated.length - 1].text === "") {
+            updated[updated.length - 1] = {
+              type: "bot",
+              text: "응답을 가져오는 데 실패했습니다.",
+            };
+          }
+          return updated;
+        });
+      },
+      token,
+      anonymousSessionId,
     );
+
+    closeEventSourceRef.current = close;
+  };
+
+  useEffect(() => {
+    chatRef.current?.scrollTo({
+      top: chatRef.current.scrollHeight,
+      behavior: "smooth",
+    });
+  }, [messages]);
+
+  return (
+    <div className={styles.chatbot}>
+      <div className={styles.chatHeader}>Global AI</div>
+      {!token && (
+        <div className={styles.loginNotice}>
+          💡 비로그인 상태에서는 대화가 짧은 기간(7일) 동안만 일시적으로
+          유지되며, 로그인하면 계정에 영구 저장됩니다.
+        </div>
+      )}
+      <div className={styles.chatBody} ref={chatRef}>
+        {messages.map((msg, index) => {
+          if (msg.type === "divider") {
+            return (
+              <div key={index} className={styles.divider}>
+                {msg.text}
+              </div>
+            );
+          }
+          return (
+            <div
+              key={index}
+              className={
+                msg.type === "bot" ? styles.botMessage : styles.userMessage
+              }
+            >
+              {msg.type === "bot" ? (
+                <div className={styles.markdown}>
+                  <ReactMarkdown>{msg.text}</ReactMarkdown>
+                </div>
+              ) : (
+                msg.text
+              )}
+            </div>
+          );
+        })}
+        {isStreaming && messages[messages.length - 1]?.text === "" && (
+          <div className={styles.botMessage}>
+            <span className={styles.typingIndicator}>
+              <span />
+              <span />
+              <span />
+            </span>
+          </div>
+        )}
+      </div>
+      <div className={styles.chatInput}>
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder={placeholder}
+          disabled={isStreaming}
+          onKeyDown={(e) => e.key === "Enter" && handleSend()}
+        />
+        <button onClick={handleSend} disabled={isStreaming}>
+          <Send size={20} />
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/FrontEnd/src/components/detailsPage/Chatbot.module.css
+++ b/FrontEnd/src/components/detailsPage/Chatbot.module.css
@@ -34,7 +34,8 @@
     color: #7a6000;
     font-size: 13px;
     padding: 7px 14px;
-    text-align: center;
+    text-align: left;
+    line-height: 1.45;
 }
 
 .chatBody {

--- a/FrontEnd/src/util/AuthContext.jsx
+++ b/FrontEnd/src/util/AuthContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect } from "react";
 import { authAPI } from "../api/authAPI";
+import { clearAnonymousSessionId } from "./anonymousSession.js";
 
 const AuthContext = createContext();
 
@@ -20,6 +21,7 @@ export const AuthProvider = ({ children }) => {
   }, [token]);
 
   const login = (newToken) => {
+    clearAnonymousSessionId();
     localStorage.setItem("token", newToken);
     setToken(newToken);
   };

--- a/FrontEnd/src/util/anonymousSession.js
+++ b/FrontEnd/src/util/anonymousSession.js
@@ -1,0 +1,18 @@
+const STORAGE_KEY = "globalTimes_anonymous_chat_session_id";
+
+/** 비로그인 기사 챗봇용 UUID. 없으면 생성해 localStorage에 둡니다. */
+export function getOrCreateAnonymousSessionId() {
+    if (typeof window === "undefined") return null;
+    let id = localStorage.getItem(STORAGE_KEY);
+    if (!id) {
+        id = crypto.randomUUID();
+        localStorage.setItem(STORAGE_KEY, id);
+    }
+    return id;
+}
+
+/** 로그인 시 호출: 익명 세션 키 제거(Redis TTL은 서버에서 만료). */
+export function clearAnonymousSessionId() {
+    if (typeof window === "undefined") return;
+    localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## 🚀 관련 이슈
- closed #85 

## 🧭 변경 타입
- [x] ✨ 기능 추가 (FEAT)

## 📝 작업 내용
### 비로그인 챗봇 · 백엔드 연동
- `localStorage`에 익명 세션 UUID(`globalTimes_anonymous_chat_session_id`) 저장, `getNewsDetailsAsk`에서 SSE URL에 `anonymousSession` 쿼리로 전달.
- `getAnonymousChatsByArticle`로 `GET /api/ai/{id}/ask/history` 호출, 비로그인도 기사 상세에서 이전 대화 복원.
- 로그인 시 `clearAnonymousSessionId()`로 익명 ID 제거 (`AuthContext`).
- `detailsAPI` / `chatAPI`에서 `VITE_APP_API ?? ""`로 상대 경로·배포 URL 대응하도록 함

### UI·문구
- 비로그인 안내: 짧은 기간(7일) 일시 유지·로그인 시 계정 저장 문구로 수정.
- 잡다한 정렬 ( 프롬프트 내 비로그인 안내 좌측으로 )

## 🔍 기술적 배경
- `EventSource`는 커스텀 헤더 제약이 있어 백엔드와 동일하게 **쿼리 `anonymousSession`** 사용.
- 대화 본문은 서버 Redis TTL, 클라이언트는 식별용 UUID만 유지.

## 🧪 테스트/검증
- [x] 비로그인: 동일 기사 연속 질문·새로고침 후 히스토리 표시
- [x] 로그인: 기존 채팅 히스토리 API 동작, 로그인 시 익명 ID 제거
- [x] 좁은 화면에서 안내 문구 줄바꿈 시 왼쪽 정렬 확인
- [x] `npm run build`(또는 프로젝트 빌드 스크립트) 통과