### PR TITLE
[FEAT] 상세 페이지 국가별 시각(Perspectives) API 연동 및 UI 추가

### DIFF
--- a/FrontEnd/src/api/detailsAPI.js
+++ b/FrontEnd/src/api/detailsAPI.js
@@ -20,6 +20,19 @@ export const getNewsDetailsSummary = async (articleId) => {
     }
 };
 
+/** 국가별 시각(Perspectives): 키워드 기반 유사 기사를 국가 코드별로 그룹 */
+export const getNewsPerspectives = async (articleId) => {
+    try {
+        const response = await axios.get(
+            `${import.meta.env.VITE_APP_API}/api/news/${articleId}/perspectives`,
+        );
+        return response.data;
+    } catch (error) {
+        console.error("국가별 관점 기사를 불러오는 데 실패했습니다.", error);
+        return null;
+    }
+};
+
 export const getNewsDetailsAsk = (
     articleId,
     question,

--- a/FrontEnd/src/components/detailsPage/PerspectivesSection.jsx
+++ b/FrontEnd/src/components/detailsPage/PerspectivesSection.jsx
@@ -1,0 +1,196 @@
+import { useEffect, useState, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { MutatingDots } from "react-loader-spinner";
+
+import TranslatedText from "../../api/TranslatedText.jsx";
+import { useLanguage } from "../../util/LanguageContext.jsx";
+import { getNewsPerspectives } from "../../api/detailsAPI.js";
+import styles from "./PerspectivesSection.module.css";
+
+function regionLabel(countryCode, locale) {
+  if (!countryCode) return "";
+  const code = String(countryCode).toUpperCase();
+  try {
+    const loc =
+      locale === "ja" ? "ja" : locale === "ko" ? "ko" : "en";
+    const dn = new Intl.DisplayNames([loc], { type: "region" });
+    return dn.of(code);
+  } catch {
+    return code;
+  }
+}
+
+function formatPublishedAt(value, dateLocale) {
+  if (value == null) return "";
+  try {
+    const d =
+      typeof value === "string" || typeof value === "number"
+        ? new Date(value)
+        : null;
+    if (d && !Number.isNaN(d.getTime())) {
+      return d.toLocaleString(dateLocale);
+    }
+  } catch {
+    /* ignore */
+  }
+  return "";
+}
+
+export default function PerspectivesSection({ articleId }) {
+  const navigate = useNavigate();
+  const { language } = useLanguage();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [payload, setPayload] = useState(null);
+
+  const dateLocale =
+    language === "ja" ? "ja-JP" : language === "ko" ? "ko-KR" : "en-US";
+
+  useEffect(() => {
+    let cancelled = false;
+    const id = Number(articleId);
+    if (!id) {
+      setLoading(false);
+      return;
+    }
+
+    (async () => {
+      setLoading(true);
+      setError(false);
+      try {
+        const res = await getNewsPerspectives(id);
+        if (cancelled) return;
+        if (res?.isSuccess && res.data) {
+          setPayload(res.data);
+        } else {
+          setPayload(null);
+        }
+      } catch {
+        if (!cancelled) setError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [articleId]);
+
+  const sortedEntries = useMemo(() => {
+    const map = payload?.perspectives;
+    if (!map || typeof map !== "object") return [];
+    return Object.entries(map).sort(([a], [b]) => a.localeCompare(b));
+  }, [payload]);
+
+  const total = payload?.totalArticles ?? 0;
+
+  if (loading) {
+    return (
+      <section className={styles.section} aria-busy="true">
+        <div className={styles.inner}>
+          <h2 className={styles.heading}>
+            <TranslatedText text="다른 나라의 관련 기사" />
+          </h2>
+          <div className={styles.loading}>
+            <MutatingDots
+              height={60}
+              width={60}
+              color="#4fa94d"
+              secondaryColor="#ccc"
+              radius={10}
+              ariaLabel="loading-perspectives"
+              visible
+            />
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <section className={styles.section}>
+        <div className={styles.inner}>
+          <h2 className={styles.heading}>
+            <TranslatedText text="다른 나라의 관련 기사" />
+          </h2>
+          <p className={styles.error}>
+            <TranslatedText text="관련 기사를 불러오지 못했습니다." />
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  if (!payload || total === 0 || sortedEntries.length === 0) {
+    return (
+      <section className={styles.section}>
+        <div className={styles.inner}>
+          <h2 className={styles.heading}>
+            <TranslatedText text="다른 나라의 관련 기사" />
+          </h2>
+          <p className={styles.empty}>
+            <TranslatedText text="해당 기사의 내용과 유사한 키워드로 타 국가 기사를 찾지 못했습니다." />
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className={styles.section}>
+      <h2 className={styles.heading}>
+        <TranslatedText text="다른 나라의 관련 기사" />
+      </h2>
+      {payload.keyword ? (
+        <p className={styles.sub}>
+          <TranslatedText text="탐색 키워드" />
+          {": "}
+          {payload.keyword}
+        </p>
+      ) : null}
+
+      {sortedEntries.map(([countryCode, articles]) => {
+        if (!Array.isArray(articles) || articles.length === 0) return null;
+        const label = regionLabel(countryCode, language);
+        return (
+          <div key={countryCode} className={styles.countryBlock}>
+            <h3 className={styles.countryTitle}>
+              {label}{" "}
+              <span style={{ fontWeight: 500, color: "#888" }}>
+                ({String(countryCode).toUpperCase()})
+              </span>
+            </h3>
+            {articles.map((article) => (
+              <button
+                key={article.id}
+                type="button"
+                className={styles.card}
+                onClick={() => navigate(`/detail/${article.id}`)}
+              >
+                <div
+                  className={styles.thumb}
+                  style={
+                    article.urlToImage
+                      ? { backgroundImage: `url(${article.urlToImage})` }
+                      : undefined
+                  }
+                />
+                <div className={styles.body}>
+                  <p className={styles.source}>{article.source}</p>
+                  <p className={styles.cardTitle}>
+                    <TranslatedText text={article.title} />
+                  </p>
+                  <p className={styles.date}>
+                    {formatPublishedAt(article.publishedAt, dateLocale)}
+                  </p>
+                </div>
+              </button>
+            ))}
+          </div>
+        );
+      })}
+    </section>
+  );
+}

--- a/FrontEnd/src/components/detailsPage/PerspectivesSection.module.css
+++ b/FrontEnd/src/components/detailsPage/PerspectivesSection.module.css
@@ -1,0 +1,150 @@
+.section {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 800px;
+  margin-top: 32px;
+  margin-left: auto;
+  margin-right: auto;
+  padding-top: 24px;
+  padding-left: 20px;
+  padding-right: 20px;
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  text-align: left;
+}
+
+.inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  width: 100%;
+  text-align: left;
+}
+
+/* 제목(h2) 줄 높이·여백을 줄여 본문과 간격 최소화 */
+.inner .heading {
+  margin: 0;
+  padding: 0;
+  line-height: 1.2;
+}
+
+.heading {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1a1a1a;
+  margin: 0 0 6px;
+  text-align: left;
+  width: 100%;
+}
+
+.sub {
+  font-size: 0.85rem;
+  color: #666;
+  margin: 0 0 16px;
+  word-break: break-word;
+}
+
+.countryBlock {
+  margin-bottom: 20px;
+}
+
+.countryBlock:last-child {
+  margin-bottom: 0;
+}
+
+.countryTitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #333;
+  margin: 0 0 10px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid rgba(201, 162, 39, 0.35);
+}
+
+.card {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  background: #fafafa;
+  cursor: pointer;
+  text-align: left;
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  border-color: rgba(201, 162, 39, 0.45);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.card:last-child {
+  margin-bottom: 0;
+}
+
+.thumb {
+  flex-shrink: 0;
+  width: 72px;
+  height: 72px;
+  border-radius: 8px;
+  background: #e8e8e8 center / cover no-repeat;
+}
+
+.body {
+  flex: 1;
+  min-width: 0;
+}
+
+.source {
+  font-size: 0.75rem;
+  color: #888;
+  margin: 0 0 4px;
+}
+
+.cardTitle {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: #222;
+  margin: 0;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.date {
+  font-size: 0.72rem;
+  color: #999;
+  margin: 6px 0 0;
+}
+
+.empty,
+.error {
+  font-size: 0.9rem;
+  color: #666;
+  margin: 0;
+  text-align: left;
+  width: 100%;
+}
+
+/* .inner 안: 제목 직후 문단 — 위 규칙보다 아래에서 간격만 최소로 */
+.inner .empty,
+.inner .error {
+  margin: 0;
+  padding: 0;
+  margin-top: 0.12rem;
+  line-height: 1.45;
+}
+
+.loading {
+  display: flex;
+  justify-content: flex-start;
+  padding: 16px 0;
+}

--- a/FrontEnd/src/pages/DetailsPage.jsx
+++ b/FrontEnd/src/pages/DetailsPage.jsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { getNewsDetails, getNewsDetailsSummary } from "../api/detailsAPI";
 import styles from "./DetailsPage.module.css";
 import ArticleDetail from "../components/detailsPage/ArticleDetail";
+import PerspectivesSection from "../components/detailsPage/PerspectivesSection";
 import Sidebar from "../components/detailsPage/Sidebar";
 import Chatbot from "../components/detailsPage/Chatbot";
 
@@ -61,6 +62,7 @@ export default function DetailsPage() {
             isLoading={isLoading}
             isSummaryLoading={isSummaryLoading}
             />
+          <PerspectivesSection articleId={id} />
           <Chatbot articleId={id} />
         </div>
         <div className={styles.sidebar}>

--- a/FrontEnd/src/pages/DetailsPage.module.css
+++ b/FrontEnd/src/pages/DetailsPage.module.css
@@ -19,6 +19,8 @@
     min-width: 0;
     display: flex;
     flex-direction: column;
+    align-items: stretch;
+    width: 100%;
 }
 
 .sidebar {


### PR DESCRIPTION
## 📌 작업 내용

- 상세 페이지에 **국가별 관련 기사(Perspectives)** API 연동 (`GET /api/news/{id}/perspectives`)
- `detailsAPI.js`: `getNewsPerspectives(articleId)` 추가
- `PerspectivesSection` 컴포넌트 추가 — 국가별 그룹, 미리보기 카드(썸네일·언론사·제목·날짜), 클릭 시 `/detail/{id}` 이동
- `DetailsPage`: `ArticleDetail`과 `Chatbot` 사이에 Perspectives 섹션 배치
- 로딩 / 에러 / 결과 없음 UI 및 좌측 정렬·제목·본문 간격 조정
- 결과 없음 문구: `해당 기사의 내용과 유사한 키워드로 타 국가 기사를 찾지 못했습니다.` 로 표시 

## ✅ 체크리스트
- [x] 로컬 확인 완료
- [x] BE 연동 확인 완료

## 🔗 관련 이슈
Closes #87 