### PR TITLE
🐛 [FIX/#92] Backend API 주소·인증·오류 응답 처리 통합

### DIFF
--- a/FrontEnd/src/api/apiClient.js
+++ b/FrontEnd/src/api/apiClient.js
@@ -1,0 +1,95 @@
+import axios from "axios";
+
+export const AUTH_EXPIRED_EVENT = "global-times:auth-expired";
+
+const baseURL = (import.meta.env.VITE_APP_API ?? "").replace(/\/+$/, "");
+
+const STATUS_MESSAGES = {
+  401: "로그인이 만료되었습니다. 다시 로그인해주세요.",
+  403: "이 요청을 처리할 권한이 없습니다.",
+  502: "외부 서비스 응답에 실패했습니다.",
+  503: "요청이 많아 잠시 후 다시 시도해주세요.",
+  504: "외부 서비스 응답 시간이 초과되었습니다.",
+};
+
+export class ApiRequestError extends Error {
+  constructor(message, { status = null, code = null, payload = null } = {}) {
+    super(message);
+    this.name = "ApiRequestError";
+    this.status = status;
+    this.code = code;
+    this.payload = payload;
+  }
+}
+
+export function normalizeApiError(
+  error,
+  fallbackMessage = "요청을 처리하지 못했습니다.",
+) {
+  if (error instanceof ApiRequestError) return error;
+
+  const payload = error?.response?.data ?? null;
+  const message =
+    payload?.message ||
+    (error?.response ? fallbackMessage : "서버에 연결할 수 없습니다.");
+
+  return new ApiRequestError(message, {
+    status: error?.response?.status ?? null,
+    code: error?.code ?? null,
+    payload,
+  });
+}
+
+export function getApiErrorMessage(error, fallbackMessage) {
+  const normalized = normalizeApiError(error, fallbackMessage);
+  if (normalized.payload?.message) return normalized.payload.message;
+  if (STATUS_MESSAGES[normalized.status]) return STATUS_MESSAGES[normalized.status];
+  if (normalized.message) return normalized.message;
+  return fallbackMessage ?? "요청을 처리하지 못했습니다.";
+}
+
+export const apiClient = axios.create({ baseURL });
+export const authAPI = axios.create({ baseURL });
+
+authAPI.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+function rejectAsApiError(error) {
+  if (axios.isCancel(error)) return Promise.reject(error);
+  return Promise.reject(normalizeApiError(error));
+}
+
+function rejectFailedEnvelope(response) {
+  const payload = response?.data;
+  if (payload?.isSuccess === false) {
+    return Promise.reject(
+      new ApiRequestError(payload.message || "요청을 처리하지 못했습니다.", {
+        status: response.status ?? null,
+        code: payload.code ?? null,
+        payload,
+      }),
+    );
+  }
+  return response;
+}
+
+apiClient.interceptors.response.use(rejectFailedEnvelope, rejectAsApiError);
+
+authAPI.interceptors.response.use(
+  rejectFailedEnvelope,
+  (error) => {
+    if (axios.isCancel(error)) return Promise.reject(error);
+
+    const normalized = normalizeApiError(error);
+    if (normalized.status === 401) {
+      localStorage.removeItem("token");
+      window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
+    }
+    return Promise.reject(normalized);
+  },
+);

--- a/FrontEnd/src/api/authAPI.js
+++ b/FrontEnd/src/api/authAPI.js
@@ -1,13 +1,1 @@
-import axios from "axios";
-
-// 인증 포함 axios 인스턴스
-export const authAPI = axios.create();
-
-// 요청 interceptor: 토큰 자동 주입
-authAPI.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token");
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
+export { authAPI } from "./apiClient";

--- a/FrontEnd/src/api/chatAPI.js
+++ b/FrontEnd/src/api/chatAPI.js
@@ -1,76 +1,37 @@
-import axios from "axios";
 import { authAPI } from "./authAPI";
-
-const apiBase = () => import.meta.env.VITE_APP_API ?? "";
-
-/** detailsAPI·SSE와 동일: 빈 문자열이면 상대 경로 `/api/...` (Vite 프록시) */
-function historyUrl(articleId) {
-    const base = apiBase();
-    return base ? `${base}/api/ai/${articleId}/ask/history` : `/api/ai/${articleId}/ask/history`;
-}
+import { apiClient } from "./apiClient";
 
 // 비로그인: Redis에 저장된 기사별 대화 (백엔드 GET /api/ai/{id}/ask/history)
 export const getAnonymousChatsByArticle = async (articleId, sessionId) => {
     if (!sessionId || !articleId) return [];
-    try {
-        const response = await axios.get(historyUrl(articleId), {
-            params: { anonymousSession: sessionId },
-        });
-        const raw = response.data?.data;
-        const list = Array.isArray(raw) ? raw : [];
-        return list.map((row) => ({
-            question: row?.question ?? row?.q ?? "",
-            answer: row?.answer ?? row?.a ?? "",
-        }));
-    } catch (error) {
-        console.error("비로그인 채팅 히스토리 조회 실패:", error?.response?.status, error?.message);
-        return [];
-    }
+    const response = await apiClient.get(`/api/ai/${articleId}/ask/history`, {
+        params: { anonymousSession: sessionId },
+    });
+    const raw = response.data?.data;
+    const list = Array.isArray(raw) ? raw : [];
+    return list.map((row) => ({
+        question: row?.question ?? row?.q ?? "",
+        answer: row?.answer ?? row?.a ?? "",
+    }));
 };
 
 // 기사별 전체 대화 내역 (상세 페이지 챗봇)
 export const getChatsByArticle = async (articleId) => {
-    try {
-        const response = await authAPI.get(`/api/articles/${articleId}/chat-history`);
-        return response.data?.data ?? [];
-    } catch (error) {
-        console.error("채팅 히스토리 조회 실패:", error);
-        return [];
-    }
+    const response = await authAPI.get(`/api/articles/${articleId}/chat-history`);
+    return response.data?.data ?? [];
 };
 
 // 기사별 마지막 대화 미리보기 목록 (플로팅 팝업, 로그인)
 export const getChatList = async () => {
-    try {
-        const response = await authAPI.get("/api/user/chat-history");
-        return response.data?.data ?? [];
-    } catch (error) {
-        console.error("채팅 히스토리 목록 조회 실패:", error);
-        return [];
-    }
+    const response = await authAPI.get("/api/user/chat-history");
+    return response.data?.data ?? [];
 };
-
-function anonymousChatListUrl() {
-    const base = apiBase();
-    return base
-        ? `${base}/api/ai/anonymous/chat-history`
-        : `/api/ai/anonymous/chat-history`;
-}
 
 /** 비로그인: 세션별 대화한 기사 목록 (플로팅, BE GET /api/ai/anonymous/chat-history) */
 export const getAnonymousChatList = async (sessionId) => {
     if (!sessionId) return [];
-    try {
-        const response = await axios.get(anonymousChatListUrl(), {
-            params: { anonymousSession: sessionId },
-        });
-        return response.data?.data ?? [];
-    } catch (error) {
-        console.error(
-            "비로그인 채팅 목록 조회 실패:",
-            error?.response?.status,
-            error?.message
-        );
-        return [];
-    }
+    const response = await apiClient.get("/api/ai/anonymous/chat-history", {
+        params: { anonymousSession: sessionId },
+    });
+    return response.data?.data ?? [];
 };

--- a/FrontEnd/src/api/detailsAPI.js
+++ b/FrontEnd/src/api/detailsAPI.js
@@ -1,36 +1,21 @@
-import axios from "axios";
+import { apiClient } from "./apiClient";
 
 export const getNewsDetails = async (articleId) => {
-    try {
-        const response = await axios.get(`${import.meta.env.VITE_APP_API}/api/news/detail?id=${articleId}`);
-        return response.data;
-    } catch (error) {
-        console.error("뉴스 상세 정보를 불러오는 데 실패했습니다.", error);
-        return null;
-    }
+    const response = await apiClient.get("/api/news/detail", {
+        params: { id: articleId },
+    });
+    return response.data;
 };
 
 export const getNewsDetailsSummary = async (articleId) => {
-    try {
-        const response = await axios.get(`${import.meta.env.VITE_APP_API}/api/ai/${articleId}/summary`);
-        return response.data;
-    } catch (error) {
-        console.error("뉴스 요약본을 불러오는 데 실패했습니다.", error);
-        return null;
-    }
+    const response = await apiClient.get(`/api/ai/${articleId}/summary`);
+    return response.data;
 };
 
 /** 국가별 시각(Perspectives): 키워드 기반 유사 기사를 국가 코드별로 그룹 */
 export const getNewsPerspectives = async (articleId) => {
-    try {
-        const response = await axios.get(
-            `${import.meta.env.VITE_APP_API}/api/news/${articleId}/perspectives`,
-        );
-        return response.data;
-    } catch (error) {
-        console.error("국가별 관점 기사를 불러오는 데 실패했습니다.", error);
-        return null;
-    }
+    const response = await apiClient.get(`/api/news/${articleId}/perspectives`);
+    return response.data;
 };
 
 export const getNewsDetailsAsk = (

--- a/FrontEnd/src/api/getNewsCardAPI.js
+++ b/FrontEnd/src/api/getNewsCardAPI.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { apiClient } from "./apiClient";
 
 function safeParseDate(s) {
   if (!s) return null;
@@ -27,46 +27,33 @@ function formatArticleDates(article) {
 // mainPage - Hot News Card //
 // response.data.data.content[0].title
 export async function getHot(page, size) {
-  try {
-    const baseUrl = `${import.meta.env.VITE_APP_API}/api/articles/popular?page=${page}&size=${size}`;
-    const response = await axios.get(baseUrl);
+  const response = await apiClient.get("/api/articles/popular", {
+    params: { page, size },
+  });
 
-    if (response.data.isSuccess === true) {
-      const formattedResults =
-        response.data.data.content.map(formatArticleDates);
-      return formattedResults;
-    } else {
-      return [];
-    }
-  } catch (error) {
-    console.error("인기 뉴스 데이터를 불러오는 데 실패했습니다:", error);
-    return [];
+  if (response.data.isSuccess === true) {
+    return response.data.data.content.map(formatArticleDates);
   }
+  return [];
 }
 
 // mainPage - Latest News Card (cursor 기반 최신순, /api/articles/latest offset 대체)
 /** @returns {{ articles: object[], nextCursor: string|null, hasNext: boolean }} */
 export async function getLatestCursor(cursor, size) {
-  try {
-    const params = new URLSearchParams({ size: String(size) });
-    if (cursor) params.set("cursor", cursor);
-    const baseUrl = `${import.meta.env.VITE_APP_API}/api/articles/cursor?${params}`;
-    const response = await axios.get(baseUrl);
+  const params = new URLSearchParams({ size: String(size) });
+  if (cursor) params.set("cursor", cursor);
+  const response = await apiClient.get(`/api/articles/cursor?${params}`);
 
-    if (response.data.isSuccess === true && response.data.data) {
-      const { articles, nextCursor, hasNext } = response.data.data;
-      const formattedResults = (articles || []).map(formatArticleDates);
-      return {
-        articles: formattedResults,
-        nextCursor: nextCursor ?? null,
-        hasNext: Boolean(hasNext),
-      };
-    }
-    return { articles: [], nextCursor: null, hasNext: false };
-  } catch (error) {
-    console.error("최근 뉴스 데이터를 불러오는 데 실패했습니다:", error);
-    return { articles: [], nextCursor: null, hasNext: false };
+  if (response.data.isSuccess === true && response.data.data) {
+    const { articles, nextCursor, hasNext } = response.data.data;
+    const formattedResults = (articles || []).map(formatArticleDates);
+    return {
+      articles: formattedResults,
+      nextCursor: nextCursor ?? null,
+      hasNext: Boolean(hasNext),
+    };
   }
+  return { articles: [], nextCursor: null, hasNext: false };
 }
 
 /** 국가·카테고리·날짜 필터 + 커서 (/api/articles/explore). 키워드 검색과는 별개 API. */
@@ -77,29 +64,23 @@ export async function getExploreArticles({
   cursor,
   size = 12,
 }) {
-  try {
-    const params = new URLSearchParams({ size: String(size) });
-    if (country) params.set("country", country);
-    if (category) params.set("category", category);
-    if (date) params.set("date", date);
-    if (cursor) params.set("cursor", cursor);
-    const baseUrl = `${import.meta.env.VITE_APP_API}/api/articles/explore?${params}`;
-    const response = await axios.get(baseUrl);
+  const params = new URLSearchParams({ size: String(size) });
+  if (country) params.set("country", country);
+  if (category) params.set("category", category);
+  if (date) params.set("date", date);
+  if (cursor) params.set("cursor", cursor);
+  const response = await apiClient.get(`/api/articles/explore?${params}`);
 
-    if (response.data.isSuccess === true && response.data.data) {
-      const { articles, nextCursor, hasNext } = response.data.data;
-      const formattedResults = (articles || []).map(formatArticleDates);
-      return {
-        articles: formattedResults,
-        nextCursor: nextCursor ?? null,
-        hasNext: Boolean(hasNext),
-      };
-    }
-    return { articles: [], nextCursor: null, hasNext: false };
-  } catch (error) {
-    console.error("탐색 기사를 불러오는 데 실패했습니다:", error);
-    return { articles: [], nextCursor: null, hasNext: false };
+  if (response.data.isSuccess === true && response.data.data) {
+    const { articles, nextCursor, hasNext } = response.data.data;
+    const formattedResults = (articles || []).map(formatArticleDates);
+    return {
+      articles: formattedResults,
+      nextCursor: nextCursor ?? null,
+      hasNext: Boolean(hasNext),
+    };
   }
+  return { articles: [], nextCursor: null, hasNext: false };
 }
 
 // mainPage - Search News Card //
@@ -107,59 +88,41 @@ export async function getExploreArticles({
 /** @param {string} input 검색어
  *  @param {{ country?: string, category?: string, date?: string }} [exploreFilters] 탐색과 동일 필터(BE /api/search 선택 파라미터) */
 export async function getSearch(input, exploreFilters = {}) {
-  try {
-    const params = new URLSearchParams();
-    params.set("text", input);
-    if (exploreFilters.country) params.set("country", exploreFilters.country);
-    if (exploreFilters.category)
-      params.set("category", exploreFilters.category);
-    if (exploreFilters.date) params.set("date", exploreFilters.date);
-    const baseUrl = `${import.meta.env.VITE_APP_API}/api/search?${params.toString()}`;
-    const response = await axios.get(baseUrl);
+  const params = new URLSearchParams();
+  params.set("text", input);
+  if (exploreFilters.country) params.set("country", exploreFilters.country);
+  if (exploreFilters.category) params.set("category", exploreFilters.category);
+  if (exploreFilters.date) params.set("date", exploreFilters.date);
+  const response = await apiClient.get(`/api/search?${params.toString()}`);
 
-    if (response.data.isSuccess === true) {
-      const originalText = response.data.data.originalText;
-      const translatedText = response.data.data.translatedText;
-      // 날짜를 분리해서 새로운 객체 생성
-      const formattedResults = response.data.data.searchArticles.map(
-        (article) => {
-          const date = new Date(article.publishedAt); // 문자열을 Date 객체로 변환
-          return {
-            ...article,
-            year: date.getFullYear().toString(),
-            month: (date.getMonth() + 1).toString().padStart(2, "0"), // 두 자리로 맞춤
-            day: date.getDate().toString().padStart(2, "0"), // 두 자리로 맞춤
-          };
-        },
-      );
-      // console.log("원래 텍스트 " + originalText);
-
+  if (response.data.isSuccess === true) {
+    const originalText = response.data.data.originalText;
+    const translatedText = response.data.data.translatedText;
+    const formattedResults = response.data.data.searchArticles.map((article) => {
+      const date = new Date(article.publishedAt);
       return {
-        results: formattedResults,
-        originalText: originalText,
-        translatedText: translatedText,
+        ...article,
+        year: date.getFullYear().toString(),
+        month: (date.getMonth() + 1).toString().padStart(2, "0"),
+        day: date.getDate().toString().padStart(2, "0"),
       };
-    } else {
-      return { results: [], translatedText: "" };
-    }
-  } catch (error) {
-    console.error("검색 뉴스 결과 데이터를 불러오는 데 실패했습니다:", error);
-    return { results: [], translatedText: "" };
+    });
+
+    return { results: formattedResults, originalText, translatedText };
   }
+  return { results: [], translatedText: "" };
 }
 
 // scrapPage - Scrap News Card //
-export async function getScrap() {
-  try {
-    const storedScrapIds = JSON.parse(localStorage.getItem("scrapIds")) || []; // 저장된 ID 가져오기
+export async function getScrap(articleIds) {
+  const storedScrapIds = articleIds ?? JSON.parse(localStorage.getItem("scrapIds")) ?? [];
 
-    if (storedScrapIds.length === 0) return [];
+  if (storedScrapIds.length === 0) return [];
 
-    const queryString = storedScrapIds.map((id) => `id=${id}`).join("&");
-    const baseUrl = `${import.meta.env.VITE_APP_API}/api/scrap?${queryString}`;
-    const response = await axios.get(baseUrl);
+  const queryString = storedScrapIds.map((id) => `id=${id}`).join("&");
+  const response = await apiClient.get(`/api/scrap?${queryString}`);
 
-    if (response.data.isSuccess) {
+  if (response.data.isSuccess) {
       // 날짜를 분리해서 새로운 객체 생성
       const formattedResults = response.data.data.map((article) => {
         if (!article.publishedAt) {
@@ -176,12 +139,7 @@ export async function getScrap() {
         };
       });
 
-      return formattedResults;
-    } else {
-      return [];
-    }
-  } catch (error) {
-    console.error("스크랩 뉴스 데이터를 불러오는 데 실패했습니다:", error);
-    return [];
+    return formattedResults;
   }
+  return [];
 }

--- a/FrontEnd/src/api/landingPageAPI.js
+++ b/FrontEnd/src/api/landingPageAPI.js
@@ -1,4 +1,4 @@
-import axios from "axios";
+import { apiClient } from "./apiClient";
 
 function isAbortError(error) {
   return (
@@ -13,33 +13,24 @@ function isAbortError(error) {
 export async function getTrend(code, options = {}) {
   const { signal } = options;
   try {
-    const baseUrl = `${import.meta.env.VITE_APP_API}/api/trend?code=${code}`;
-    const response = await axios.get(baseUrl, { signal });
+    const response = await apiClient.get("/api/trend", {
+      params: { code },
+      signal,
+    });
     return response.data;
   } catch (error) {
     if (isAbortError(error)) throw error;
-    console.error("트렌드 데이터를 불러오는 데 실패했습니다:", error);
-    return {
-      isSuccess: false,
-      data: [],
-      timestamp: new Date().toISOString(),
-      message: "",
-    };
+    throw error;
   }
 }
 
 export const getSummary = async (url) => {
-  try {
-    const response = await axios.get(`${import.meta.env.VITE_APP_API}/api/trend/summary?url=${encodeURIComponent(url)}`);
-    
-    // 응답이 성공적이고 data가 존재하면 반환
-    if (response.data?.isSuccess && response.data?.data) {
-      return response.data.data;
-    } else {
-      return "해당 언론사는 요약 정보 제공이 불가능합니다."; // 실패 또는 data가 없는 경우
-    }
-  } catch (error) {
-    console.error("요약을 가져오는 데 실패했습니다:", error);
-    return "해당 언론사는 요약 정보 제공이 불가능합니다."; // API 호출 자체가 실패한 경우
+  const response = await apiClient.get("/api/trend/summary", {
+    params: { url },
+  });
+
+  if (response.data?.isSuccess && response.data?.data) {
+    return response.data.data;
   }
+  return "해당 언론사는 요약 정보 제공이 불가능합니다.";
 };

--- a/FrontEnd/src/api/scrapAPI.js
+++ b/FrontEnd/src/api/scrapAPI.js
@@ -2,33 +2,18 @@ import { authAPI } from "./authAPI";
 
 // 스크랩 토글 (로그인 필요) → { scrapped: true/false }
 export const toggleScrap = async (articleId) => {
-    try {
-        const response = await authAPI.post(`/api/articles/${articleId}/scrap`);
-        return response.data?.data?.scrapped ?? false;
-    } catch (error) {
-        console.error("스크랩 토글 실패:", error);
-        return null;
-    }
+    const response = await authAPI.post(`/api/articles/${articleId}/scrap`);
+    return response.data?.data?.scrapped ?? false;
 };
 
 // 내 스크랩 목록 (로그인 필요) → ScrapListResDTO[]
 export const getMyScrapList = async () => {
-    try {
-        const response = await authAPI.get("/api/user/scraps");
-        return response.data?.data ?? [];
-    } catch (error) {
-        console.error("스크랩 목록 조회 실패:", error);
-        return [];
-    }
+    const response = await authAPI.get("/api/user/scraps");
+    return response.data?.data ?? [];
 };
 
 // 특정 기사 스크랩 여부 (로그인 필요) → true/false
 export const getScrapStatus = async (articleId) => {
-    try {
-        const response = await authAPI.get(`/api/articles/${articleId}/scrap/status`);
-        return response.data?.data?.scrapped ?? false;
-    } catch (error) {
-        console.error("스크랩 상태 조회 실패:", error);
-        return false;
-    }
+    const response = await authAPI.get(`/api/articles/${articleId}/scrap/status`);
+    return response.data?.data?.scrapped ?? false;
 };

--- a/FrontEnd/src/components/chat/ChatHistoryButton.jsx
+++ b/FrontEnd/src/components/chat/ChatHistoryButton.jsx
@@ -10,6 +10,8 @@ import TranslatedText from "../../api/TranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import { useTranslatedLabel } from "../../hooks/useTranslatedLabel.js";
 import { formatLocal } from "../../util/date";
+import { getApiErrorMessage } from "../../api/apiClient";
+import ApiErrorMessage from "../commons/apiState/ApiErrorMessage";
 
 export default function ChatHistoryButton() {
   const { token } = useAuth();
@@ -19,6 +21,7 @@ export default function ChatHistoryButton() {
   const [isOpen, setIsOpen] = useState(false);
   const [chatList, setChatList] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [loadError, setLoadError] = useState("");
   const popupRef = useRef(null);
 
   // 팝업 열 때: 로그인 → DB 목록, 비로그인 → Redis 세션 목록
@@ -26,6 +29,7 @@ export default function ChatHistoryButton() {
     if (!isOpen) return;
     const fetchList = async () => {
       setIsLoading(true);
+      setLoadError("");
       try {
         if (token) {
           const data = await getChatList();
@@ -35,6 +39,9 @@ export default function ChatHistoryButton() {
           const data = await getAnonymousChatList(sid);
           setChatList(data);
         }
+      } catch (error) {
+        setChatList([]);
+        setLoadError(getApiErrorMessage(error, "대화 목록을 불러오지 못했습니다."));
       } finally {
         setIsLoading(false);
       }
@@ -72,6 +79,7 @@ export default function ChatHistoryButton() {
             </button>
           </div>
           <div className={styles.popupBody}>
+            <ApiErrorMessage message={loadError} />
             {isLoading && (
               <p className={styles.empty}>
                 <TranslatedText text="불러오는 중..." />

--- a/FrontEnd/src/components/commons/apiState/ApiErrorMessage.jsx
+++ b/FrontEnd/src/components/commons/apiState/ApiErrorMessage.jsx
@@ -1,0 +1,27 @@
+import PropTypes from "prop-types";
+import { RotateCcw } from "lucide-react";
+import TranslatedText from "../../../api/TranslatedText";
+import styles from "./ApiErrorMessage.module.css";
+
+export default function ApiErrorMessage({ message, onRetry = null }) {
+  if (!message) return null;
+
+  return (
+    <div className={styles.notice} role="alert">
+      <p>
+        <TranslatedText text={message} />
+      </p>
+      {onRetry && (
+        <button type="button" onClick={onRetry} title="다시 시도">
+          <RotateCcw size={16} aria-hidden />
+          <TranslatedText text="다시 시도" />
+        </button>
+      )}
+    </div>
+  );
+}
+
+ApiErrorMessage.propTypes = {
+  message: PropTypes.string,
+  onRetry: PropTypes.func,
+};

--- a/FrontEnd/src/components/commons/apiState/ApiErrorMessage.module.css
+++ b/FrontEnd/src/components/commons/apiState/ApiErrorMessage.module.css
@@ -1,0 +1,43 @@
+.notice {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  box-sizing: border-box;
+  margin: 12px 0;
+  padding: 12px 14px;
+  border-left: 3px solid #b63c3c;
+  background: #fff6f6;
+  color: #762626;
+  font-size: 14px;
+  line-height: 1.5;
+}
+
+.notice p {
+  margin: 0;
+}
+
+.notice button {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 6px;
+  border: 1px solid #b63c3c;
+  background: #fff;
+  color: #762626;
+  padding: 7px 10px;
+  cursor: pointer;
+}
+
+.notice button:hover {
+  background: #fceaea;
+}
+
+@media (max-width: 480px) {
+  .notice {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
+++ b/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
@@ -1,6 +1,7 @@
 import styles from "./ArticleDetail.module.css";
 import { FaBookmark } from "react-icons/fa";
 import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import { MutatingDots } from "react-loader-spinner";
 import ReactMarkdown from "react-markdown";
 
@@ -10,6 +11,8 @@ import { useAuth } from "../../util/AuthContext.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import { useTranslatedLabel } from "../../hooks/useTranslatedLabel.js";
 import { toggleScrap, getScrapStatus } from "../../api/scrapAPI.js";
+import { getApiErrorMessage } from "../../api/apiClient.js";
+import ApiErrorMessage from "../commons/apiState/ApiErrorMessage.jsx";
 
 /** RSS/DB에 url이 없거나 문자열 "null" 등인 경우 — img 렌더 생략 */
 function hasArticleImageUrl(url) {
@@ -25,6 +28,7 @@ export default function ArticleDetail({
   content,
   isLoading,
   isSummaryLoading,
+  summaryError,
 }) {
   const articleId = Number(id);
   const { title, author, sourceName, publishedAt, viewCount, urlToImage } =
@@ -39,12 +43,17 @@ export default function ArticleDetail({
   const [imageLoadFailed, setImageLoadFailed] = useState(false);
   /** 요약 마크다운: 전역 UI 언어로 번역된 문자열 (제목과 동일하게 Google 번역) */
   const [translatedMarkdown, setTranslatedMarkdown] = useState("");
+  const [scrapError, setScrapError] = useState("");
 
   useEffect(() => {
     const initScrapStatus = async () => {
       if (token) {
-        const status = await getScrapStatus(articleId);
-        setIsScrapped(status);
+        try {
+          const status = await getScrapStatus(articleId);
+          setIsScrapped(status);
+        } catch (error) {
+          setScrapError(getApiErrorMessage(error, "스크랩 상태를 확인하지 못했습니다."));
+        }
       } else {
         const storedScrapIds =
           JSON.parse(localStorage.getItem("scrapIds")) || [];
@@ -83,8 +92,13 @@ export default function ArticleDetail({
   async function handleConfirmScrap() {
     setShowModal(false);
     if (token) {
-      const result = await toggleScrap(articleId);
-      if (result !== null) setIsScrapped(result);
+      try {
+        setScrapError("");
+        const result = await toggleScrap(articleId);
+        setIsScrapped(result);
+      } catch (error) {
+        setScrapError(getApiErrorMessage(error, "스크랩을 변경하지 못했습니다."));
+      }
     } else {
       const storedScrapIds = JSON.parse(localStorage.getItem("scrapIds")) || [];
       if (!storedScrapIds.includes(articleId)) {
@@ -101,6 +115,23 @@ export default function ArticleDetail({
 
   const dateLocale =
     language === "ja" ? "ja-JP" : language === "ko" ? "ko-KR" : "en-US";
+
+  if (isLoading) {
+    return (
+      <div className={styles.articleDetail} aria-busy="true">
+        <MutatingDots
+          height={100}
+          width={100}
+          color="#4fa94d"
+          secondaryColor="#ccc"
+          radius={12.5}
+          ariaLabel="article-detail-loading"
+          visible
+        />
+      </div>
+    );
+  }
+
   return (
     <div className={styles.articleDetail}>
       {/* 스크랩 확인 모달 */}
@@ -189,6 +220,7 @@ export default function ArticleDetail({
       <p className={styles.meta}>
         {sourceName} - {author}
       </p>
+      <ApiErrorMessage message={scrapError} />
       {hasArticleImageUrl(urlToImage) && !imageLoadFailed ? (
         <img
           src={urlToImage.trim()}
@@ -208,6 +240,8 @@ export default function ArticleDetail({
           ariaLabel="mutating-dots-loading"
           visible={true}
         />
+      ) : summaryError ? (
+        <ApiErrorMessage message={summaryError} />
       ) : content ? (
         <div className={styles.content}>
           <ReactMarkdown>{translatedMarkdown}</ReactMarkdown>
@@ -220,3 +254,19 @@ export default function ArticleDetail({
     </div>
   );
 }
+
+ArticleDetail.propTypes = {
+  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  newsDetail: PropTypes.shape({
+    title: PropTypes.string,
+    author: PropTypes.string,
+    sourceName: PropTypes.string,
+    publishedAt: PropTypes.string,
+    viewCount: PropTypes.number,
+    urlToImage: PropTypes.string,
+  }).isRequired,
+  content: PropTypes.string,
+  isLoading: PropTypes.bool.isRequired,
+  isSummaryLoading: PropTypes.bool.isRequired,
+  summaryError: PropTypes.string,
+};

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from "react";
+import PropTypes from "prop-types";
 import styles from "./Chatbot.module.css";
 import { Send } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -13,11 +14,14 @@ import { fetchTranslatedText } from "../../api/fetchTranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import { useAuth } from "../../util/AuthContext.jsx";
 import { getOrCreateAnonymousSessionId } from "../../util/anonymousSession.js";
+import { getApiErrorMessage } from "../../api/apiClient.js";
+import ApiErrorMessage from "../commons/apiState/ApiErrorMessage.jsx";
 
 export default function Chatbot({ articleId }) {
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState([]);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [historyError, setHistoryError] = useState("");
   const chatRef = useRef(null);
   const closeEventSourceRef = useRef(null);
 
@@ -41,6 +45,7 @@ export default function Chatbot({ articleId }) {
       );
       if (cancelled) return;
       setPlaceholder(translatedPlaceholder);
+      setHistoryError("");
 
       const buildFromHistory = (history, greeting) => {
         if (!history?.length) {
@@ -65,20 +70,26 @@ export default function Chatbot({ articleId }) {
         ];
       };
 
-      if (token && articleId) {
-        const history = await getChatsByArticle(articleId);
-        if (cancelled) return;
-        setMessages(buildFromHistory(history, translatedGreeting));
-      } else if (articleId) {
-        const sessionId = getOrCreateAnonymousSessionId();
-        const history = sessionId
-          ? await getAnonymousChatsByArticle(articleId, sessionId)
-          : [];
-        if (cancelled) return;
-        setMessages(buildFromHistory(history, translatedGreeting));
-      } else {
+      try {
+        if (token && articleId) {
+          const history = await getChatsByArticle(articleId);
+          if (cancelled) return;
+          setMessages(buildFromHistory(history, translatedGreeting));
+        } else if (articleId) {
+          const sessionId = getOrCreateAnonymousSessionId();
+          const history = sessionId
+            ? await getAnonymousChatsByArticle(articleId, sessionId)
+            : [];
+          if (cancelled) return;
+          setMessages(buildFromHistory(history, translatedGreeting));
+        } else {
+          if (cancelled) return;
+          setMessages([{ type: "bot", text: translatedGreeting }]);
+        }
+      } catch (error) {
         if (cancelled) return;
         setMessages([{ type: "bot", text: translatedGreeting }]);
+        setHistoryError(getApiErrorMessage(error, "이전 대화를 불러오지 못했습니다."));
       }
     };
 
@@ -159,6 +170,7 @@ export default function Chatbot({ articleId }) {
           <TranslatedText text="비로그인 상태에서는 대화가 짧은 기간(7일) 동안만 일시적으로 유지되며, 로그인하면 계정에 영구 저장됩니다." />
         </div>
       )}
+      <ApiErrorMessage message={historyError} />
       <div className={styles.chatBody} ref={chatRef}>
         {messages.map((msg, index) => {
           if (msg.type === "divider") {
@@ -226,3 +238,7 @@ export default function Chatbot({ articleId }) {
     </div>
   );
 }
+
+Chatbot.propTypes = {
+  articleId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};

--- a/FrontEnd/src/components/detailsPage/PerspectivesSection.jsx
+++ b/FrontEnd/src/components/detailsPage/PerspectivesSection.jsx
@@ -1,10 +1,13 @@
 import { useEffect, useState, useMemo } from "react";
+import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import { MutatingDots } from "react-loader-spinner";
 
 import TranslatedText from "../../api/TranslatedText.jsx";
 import { useLanguage } from "../../util/LanguageContext.jsx";
 import { getNewsPerspectives } from "../../api/detailsAPI.js";
+import { getApiErrorMessage } from "../../api/apiClient.js";
+import ApiErrorMessage from "../commons/apiState/ApiErrorMessage.jsx";
 import styles from "./PerspectivesSection.module.css";
 import { parseApiDate } from "../../util/date";
 
@@ -46,7 +49,7 @@ export default function PerspectivesSection({ articleId }) {
   const navigate = useNavigate();
   const { language } = useLanguage();
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [error, setError] = useState("");
   const [payload, setPayload] = useState(null);
 
   const dateLocale =
@@ -62,7 +65,7 @@ export default function PerspectivesSection({ articleId }) {
 
     (async () => {
       setLoading(true);
-      setError(false);
+      setError("");
       try {
         const res = await getNewsPerspectives(id);
         if (cancelled) return;
@@ -71,8 +74,10 @@ export default function PerspectivesSection({ articleId }) {
         } else {
           setPayload(null);
         }
-      } catch {
-        if (!cancelled) setError(true);
+      } catch (requestError) {
+        if (!cancelled) {
+          setError(getApiErrorMessage(requestError, "관련 기사를 불러오지 못했습니다."));
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -126,9 +131,7 @@ export default function PerspectivesSection({ articleId }) {
           <h2 className={styles.heading}>
             <TranslatedText text="다른 나라의 관련 기사" />
           </h2>
-          <p className={styles.error}>
-            <TranslatedText text="관련 기사를 불러오지 못했습니다." />
-          </p>
+          <ApiErrorMessage message={error} />
         </div>
       </section>
     );
@@ -218,3 +221,7 @@ export default function PerspectivesSection({ articleId }) {
     </section>
   );
 }
+
+PerspectivesSection.propTypes = {
+  articleId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};

--- a/FrontEnd/src/components/globe/Globe.jsx
+++ b/FrontEnd/src/components/globe/Globe.jsx
@@ -4,6 +4,7 @@ import TrendModal from "./TrendModal";
 import NewsModal from "./NewsModal";
 import { getTrend } from "../../api/landingPageAPI";
 import styles from "./Globe.module.css";
+import { getApiErrorMessage } from "../../api/apiClient";
 
 const BASE_THETA = 0.3;
 
@@ -258,7 +259,7 @@ const GlobeComponent = () => {
           isSuccess: false,
           data: [],
           timestamp: new Date().toISOString(),
-          message: "",
+          message: getApiErrorMessage(err, "트렌드 정보를 불러오지 못했습니다."),
         });
       });
 
@@ -322,11 +323,8 @@ const GlobeComponent = () => {
             country={COUNTRY_MARKERS[selectedCountry].name}
             trends={trendData.data}
             timestamp={trendData.timestamp}
+            errorMessage={trendData.isSuccess === false ? trendData.message : ""}
             onSelect={(news) => setSelectedNews(news)}
-            onClose={() => {
-              setSelectedCountry(null);
-              setTrendData(null);
-            }}
           />
         </div>
       )}

--- a/FrontEnd/src/components/globe/NewsModal.jsx
+++ b/FrontEnd/src/components/globe/NewsModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import styles from "./NewsModal.module.css";
 import { IoClose } from "react-icons/io5";
 import { getSummary } from "../../api/landingPageAPI";
@@ -6,6 +7,7 @@ import { ClipLoader } from "react-spinners";
 
 // 번역 컴포넌트
 import TranslatedText from "../../api/TranslatedText";
+import { getApiErrorMessage } from "../../api/apiClient";
 
 const NewsModal = ({ news, onClose }) => {
   const [summary, setSummary] = useState("");
@@ -16,7 +18,9 @@ const NewsModal = ({ news, onClose }) => {
       setIsLoading(true); // 요청 시작
       getSummary(news.url)
         .then((data) => setSummary(data))
-        .catch(() => setSummary("해당 언론사는 요약 정보 제공이 불가능합니다."))
+        .catch((error) =>
+          setSummary(getApiErrorMessage(error, "요약 정보를 불러오지 못했습니다.")),
+        )
         .finally(() => setIsLoading(false)); // 요청 완료
     }
   }, [news?.url]);
@@ -63,3 +67,13 @@ const NewsModal = ({ news, onClose }) => {
 };
 
 export default NewsModal;
+
+NewsModal.propTypes = {
+  news: PropTypes.shape({
+    url: PropTypes.string,
+    sourceName: PropTypes.string,
+    title: PropTypes.string,
+    urlToImage: PropTypes.string,
+  }),
+  onClose: PropTypes.func.isRequired,
+};

--- a/FrontEnd/src/components/globe/TrendModal.jsx
+++ b/FrontEnd/src/components/globe/TrendModal.jsx
@@ -1,9 +1,11 @@
 import styles from "./TrendModal.module.css";
+import PropTypes from "prop-types";
 import { formatLocal } from "../../util/date";
 import TranslatedText from "../../api/TranslatedText";
 import { useLanguage } from "../../util/LanguageContext.jsx";
+import ApiErrorMessage from "../commons/apiState/ApiErrorMessage.jsx";
 
-const TrendModal = ({ country, trends, timestamp, onSelect, onClose }) => {
+const TrendModal = ({ country, trends, timestamp, errorMessage, onSelect }) => {
   const { language } = useLanguage();
   const dateLocale =
     language === "ja" ? "ja-JP" : language === "ko" ? "ko-KR" : "en-US";
@@ -20,13 +22,17 @@ const TrendModal = ({ country, trends, timestamp, onSelect, onClose }) => {
         </p>
       </div>
 
-      <ul>
-        {trends.map((trend, index) => (
-          <li key={index} onClick={() => onSelect(trend)}>
-            {trend.keyword}
-          </li>
-        ))}
-      </ul>
+      {errorMessage ? (
+        <ApiErrorMessage message={errorMessage} />
+      ) : (
+        <ul>
+          {trends.map((trend, index) => (
+            <li key={index} onClick={() => onSelect(trend)}>
+              {trend.keyword}
+            </li>
+          ))}
+        </ul>
+      )}
 
       <p className={styles.copyright}>
         <TranslatedText text="본 페이지에 표시된 트렌드 데이터는 " />
@@ -44,3 +50,15 @@ const TrendModal = ({ country, trends, timestamp, onSelect, onClose }) => {
 };
 
 export default TrendModal;
+
+TrendModal.propTypes = {
+  country: PropTypes.string.isRequired,
+  trends: PropTypes.arrayOf(
+    PropTypes.shape({
+      keyword: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  timestamp: PropTypes.string,
+  errorMessage: PropTypes.string,
+  onSelect: PropTypes.func.isRequired,
+};

--- a/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
+++ b/FrontEnd/src/components/mainPage/ExploreResultsSection.jsx
@@ -4,9 +4,11 @@ import CursorPagination from "./CursorPagination";
 import TranslatedText from "../../api/TranslatedText";
 import PropTypes from "prop-types";
 import { useTranslatedLabel } from "../../hooks/useTranslatedLabel.js";
+import ApiErrorMessage from "../commons/apiState/ApiErrorMessage.jsx";
 
 export default function ExploreResultsSection({
   loading,
+  error,
   articles,
   pageLabel,
   canPrev,
@@ -49,6 +51,8 @@ export default function ExploreResultsSection({
         <p className={styled["ExploreSection__loading"]}>
           <TranslatedText text="불러오는 중…" />
         </p>
+      ) : error ? (
+        <ApiErrorMessage message={error} onRetry={onFirst} />
       ) : articles.length === 0 ? (
         <p className={styled["ExploreSection__empty"]}>
           <TranslatedText text="조건에 맞는 기사가 없습니다." />
@@ -88,6 +92,7 @@ export default function ExploreResultsSection({
 
 ExploreResultsSection.propTypes = {
   loading: PropTypes.bool.isRequired,
+  error: PropTypes.string,
   articles: PropTypes.arrayOf(PropTypes.object).isRequired,
   pageLabel: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
     .isRequired,

--- a/FrontEnd/src/components/mainPage/MainNews.jsx
+++ b/FrontEnd/src/components/mainPage/MainNews.jsx
@@ -9,6 +9,8 @@ import { useState, useEffect, useCallback } from "react";
 import TranslatedText from "../../api/TranslatedText";
 
 import { getHot, getLatestCursor } from "../../api/getNewsCardAPI";
+import { getApiErrorMessage } from "../../api/apiClient";
+import ApiErrorMessage from "../commons/apiState/ApiErrorMessage";
 
 const LATEST_PAGE_SIZE = 8;
 
@@ -16,6 +18,7 @@ export default function MainNews() {
   const [hotNews, setHotNews] = useState([]);
   const [basicNews, setBasicNews] = useState([]);
   const [hotPage, setHotPage] = useState(1);
+  const [hotError, setHotError] = useState("");
   const hotTotalPages = 7;
 
   const [latestNextCursor, setLatestNextCursor] = useState(null);
@@ -24,15 +27,17 @@ export default function MainNews() {
   const [latestRequestCursor, setLatestRequestCursor] = useState(null);
   /** 다음으로 갈 때 push(latestRequestCursor) — 이전으로 갈 때 pop 한 값으로 재요청 */
   const [latestStack, setLatestStack] = useState([]);
+  const [latestError, setLatestError] = useState("");
 
   useEffect(() => {
     async function fetchHotNews() {
-      const data = await getHot(hotPage - 1, 6);
-
-      if (data && typeof data === "object") {
+      setHotError("");
+      try {
+        const data = await getHot(hotPage - 1, 6);
         setHotNews(Object.values(data));
-      } else {
-        console.error("🚨 예상과 다른 데이터 구조:", data);
+      } catch (error) {
+        setHotNews([]);
+        setHotError(getApiErrorMessage(error, "인기 기사를 불러오지 못했습니다."));
       }
     }
     fetchHotNews();
@@ -44,12 +49,25 @@ export default function MainNews() {
     setLatestHasNext(res.hasNext);
   }, []);
 
-  const loadLatestFirst = useCallback(async () => {
-    const res = await getLatestCursor(null, LATEST_PAGE_SIZE);
-    applyLatestResponse(res);
-    setLatestRequestCursor(null);
-    setLatestStack([]);
+  const requestLatest = useCallback(async (cursor) => {
+    setLatestError("");
+    try {
+      const res = await getLatestCursor(cursor, LATEST_PAGE_SIZE);
+      applyLatestResponse(res);
+      return true;
+    } catch (error) {
+      setLatestError(getApiErrorMessage(error, "최신 기사를 불러오지 못했습니다."));
+      return false;
+    }
   }, [applyLatestResponse]);
+
+  const loadLatestFirst = useCallback(async () => {
+    const succeeded = await requestLatest(null);
+    if (succeeded) {
+      setLatestRequestCursor(null);
+      setLatestStack([]);
+    }
+  }, [requestLatest]);
 
   useEffect(() => {
     loadLatestFirst();
@@ -57,25 +75,27 @@ export default function MainNews() {
 
   const handleLatestNext = useCallback(async () => {
     if (!latestHasNext || latestNextCursor == null) return;
-    setLatestStack((s) => [...s, latestRequestCursor]);
-    const res = await getLatestCursor(latestNextCursor, LATEST_PAGE_SIZE);
-    applyLatestResponse(res);
-    setLatestRequestCursor(latestNextCursor);
+    const succeeded = await requestLatest(latestNextCursor);
+    if (succeeded) {
+      setLatestStack((s) => [...s, latestRequestCursor]);
+      setLatestRequestCursor(latestNextCursor);
+    }
   }, [
     latestHasNext,
     latestNextCursor,
     latestRequestCursor,
-    applyLatestResponse,
+    requestLatest,
   ]);
 
   const handleLatestPrev = useCallback(async () => {
     if (latestStack.length === 0) return;
     const parentCursor = latestStack[latestStack.length - 1];
-    setLatestStack((s) => s.slice(0, -1));
-    const res = await getLatestCursor(parentCursor, LATEST_PAGE_SIZE);
-    applyLatestResponse(res);
-    setLatestRequestCursor(parentCursor);
-  }, [latestStack, applyLatestResponse]);
+    const succeeded = await requestLatest(parentCursor);
+    if (succeeded) {
+      setLatestStack((s) => s.slice(0, -1));
+      setLatestRequestCursor(parentCursor);
+    }
+  }, [latestStack, requestLatest]);
 
   const handleLatestFirst = useCallback(async () => {
     await loadLatestFirst();
@@ -97,6 +117,7 @@ export default function MainNews() {
         </div>
 
         <div className={styled["MainNews--News"]}>
+          {hotError && <ApiErrorMessage message={hotError} />}
           {hotNews.map((news) => (
             <HotNewsCard
               key={news.id}
@@ -132,6 +153,9 @@ export default function MainNews() {
         </div>
 
         <div className={styled["MainNews--News__latest"]}>
+          {latestError && (
+            <ApiErrorMessage message={latestError} onRetry={handleLatestFirst} />
+          )}
           {basicNews.map((news) => (
             <BasicNewsCard
               key={news.id}

--- a/FrontEnd/src/pages/DetailsPage.jsx
+++ b/FrontEnd/src/pages/DetailsPage.jsx
@@ -6,18 +6,23 @@ import ArticleDetail from "../components/detailsPage/ArticleDetail";
 import PerspectivesSection from "../components/detailsPage/PerspectivesSection";
 import Sidebar from "../components/detailsPage/Sidebar";
 import Chatbot from "../components/detailsPage/Chatbot";
+import ApiErrorMessage from "../components/commons/apiState/ApiErrorMessage";
+import { getApiErrorMessage } from "../api/apiClient";
 
 export default function DetailsPage() {
   const { id } = useParams();
-  const [newsDetail, setNewsDetail] = useState("");
+  const [newsDetail, setNewsDetail] = useState({});
   const [recentNewsList, setRecentNewsList] = useState([]);
   const [content, setContent] = useState("");
   const [isLoading, setIsLoading] = useState(true);
   const [isSummaryLoading, setIsSummaryLoading] = useState(true);
+  const [detailError, setDetailError] = useState("");
+  const [summaryError, setSummaryError] = useState("");
 
   useEffect(() => {
     const fetchDetail = async () => {
       setIsLoading(true);
+      setDetailError("");
       try {
         const detailRes = await getNewsDetails(id);
         if (detailRes?.isSuccess) {
@@ -25,7 +30,7 @@ export default function DetailsPage() {
           setRecentNewsList(detailRes.data.recentNewsList);
         }
       } catch (error) {
-        console.error("상세 정보 로딩 실패:", error);
+        setDetailError(getApiErrorMessage(error, "기사 정보를 불러오지 못했습니다."));
       } finally {
         setIsLoading(false);
       }
@@ -33,13 +38,14 @@ export default function DetailsPage() {
 
     const fetchSummary = async () => {
       setIsSummaryLoading(true);
+      setSummaryError("");
       try {
         const summaryRes = await getNewsDetailsSummary(id);
         if (summaryRes && typeof summaryRes.data === "string") {
           setContent(summaryRes.data);
         }
       } catch (error) {
-        console.error("요약 로딩 실패:", error);
+        setSummaryError(getApiErrorMessage(error, "기사 요약을 불러오지 못했습니다."));
       } finally {
         setIsSummaryLoading(false);
       }
@@ -55,15 +61,22 @@ export default function DetailsPage() {
     <div className={styles.detailsPage}>
       <div className={styles.content}>
         <div className={styles.article}>
-          <ArticleDetail 
-            id={id} 
-            newsDetail={newsDetail} 
-            content={content} 
-            isLoading={isLoading}
-            isSummaryLoading={isSummaryLoading}
-            />
-          <PerspectivesSection articleId={id} />
-          <Chatbot articleId={id} />
+          {detailError ? (
+            <ApiErrorMessage message={detailError} />
+          ) : (
+            <>
+              <ArticleDetail
+                id={id}
+                newsDetail={newsDetail}
+                content={content}
+                isLoading={isLoading}
+                isSummaryLoading={isSummaryLoading}
+                summaryError={summaryError}
+              />
+              <PerspectivesSection articleId={id} />
+              <Chatbot articleId={id} />
+            </>
+          )}
         </div>
         <div className={styles.sidebar}>
           <Sidebar recentNewsList={recentNewsList} />

--- a/FrontEnd/src/pages/MainPage.jsx
+++ b/FrontEnd/src/pages/MainPage.jsx
@@ -4,6 +4,7 @@ import MainNews from "../components/mainPage/MainNews";
 import ExploreResultsSection from "../components/mainPage/ExploreResultsSection";
 import { useState, useCallback } from "react";
 import { getExploreArticles } from "../api/getNewsCardAPI";
+import { getApiErrorMessage } from "../api/apiClient";
 
 const EXPLORE_PAGE_SIZE = 12;
 
@@ -16,6 +17,7 @@ export default function MainPage() {
   const [exploreFilters, setExploreFilters] = useState({});
   const [exploreStack, setExploreStack] = useState([]);
   const [exploreRequestCursor, setExploreRequestCursor] = useState(null);
+  const [exploreError, setExploreError] = useState("");
 
   const applyExploreResponse = useCallback((res) => {
     setExploreArticles(res.articles);
@@ -23,67 +25,82 @@ export default function MainPage() {
     setExploreHasNext(res.hasNext);
   }, []);
 
+  const requestExplore = useCallback(async (params) => {
+    setExploreLoading(true);
+    setExploreError("");
+    try {
+      const res = await getExploreArticles(params);
+      applyExploreResponse(res);
+      return true;
+    } catch (error) {
+      setExploreError(getApiErrorMessage(error, "탐색 결과를 불러오지 못했습니다."));
+      return false;
+    } finally {
+      setExploreLoading(false);
+    }
+  }, [applyExploreResponse]);
+
   const handleExploreApply = useCallback(
     async (filters) => {
-      setExploreLoading(true);
       setExploreActive(true);
       setExploreFilters(filters);
-      const res = await getExploreArticles({
+      const succeeded = await requestExplore({
         ...filters,
         cursor: null,
         size: EXPLORE_PAGE_SIZE,
       });
-      applyExploreResponse(res);
-      setExploreStack([]);
-      setExploreRequestCursor(null);
-      setExploreLoading(false);
+      if (succeeded) {
+        setExploreStack([]);
+        setExploreRequestCursor(null);
+      }
     },
-    [applyExploreResponse],
+    [requestExplore],
   );
 
   const handleExploreFirst = useCallback(async () => {
-    setExploreLoading(true);
-    const res = await getExploreArticles({
+    const succeeded = await requestExplore({
       ...exploreFilters,
       cursor: null,
       size: EXPLORE_PAGE_SIZE,
     });
-    applyExploreResponse(res);
-    setExploreStack([]);
-    setExploreRequestCursor(null);
-    setExploreLoading(false);
-  }, [exploreFilters, applyExploreResponse]);
+    if (succeeded) {
+      setExploreStack([]);
+      setExploreRequestCursor(null);
+    }
+  }, [exploreFilters, requestExplore]);
 
   const handleExploreNext = useCallback(async () => {
     if (!exploreHasNext || exploreNextCursor == null) return;
-    setExploreStack((s) => [...s, exploreRequestCursor]);
-    const res = await getExploreArticles({
+    const succeeded = await requestExplore({
       ...exploreFilters,
       cursor: exploreNextCursor,
       size: EXPLORE_PAGE_SIZE,
     });
-    applyExploreResponse(res);
-    setExploreRequestCursor(exploreNextCursor);
+    if (succeeded) {
+      setExploreStack((s) => [...s, exploreRequestCursor]);
+      setExploreRequestCursor(exploreNextCursor);
+    }
   }, [
     exploreHasNext,
     exploreNextCursor,
     exploreRequestCursor,
     exploreFilters,
-    applyExploreResponse,
+    requestExplore,
   ]);
 
   const handleExplorePrev = useCallback(async () => {
     if (exploreStack.length === 0) return;
     const parentCursor = exploreStack[exploreStack.length - 1];
-    setExploreStack((s) => s.slice(0, -1));
-    const res = await getExploreArticles({
+    const succeeded = await requestExplore({
       ...exploreFilters,
       cursor: parentCursor,
       size: EXPLORE_PAGE_SIZE,
     });
-    applyExploreResponse(res);
-    setExploreRequestCursor(parentCursor);
-  }, [exploreStack, exploreFilters, applyExploreResponse]);
+    if (succeeded) {
+      setExploreStack((s) => s.slice(0, -1));
+      setExploreRequestCursor(parentCursor);
+    }
+  }, [exploreStack, exploreFilters, requestExplore]);
 
   const handleExploreDismiss = useCallback(() => {
     setExploreActive(false);
@@ -93,6 +110,7 @@ export default function MainPage() {
     setExploreFilters({});
     setExploreStack([]);
     setExploreRequestCursor(null);
+    setExploreError("");
   }, []);
 
   const explorePageLabel = exploreStack.length + 1;
@@ -108,6 +126,7 @@ export default function MainPage() {
       {exploreActive && (
         <ExploreResultsSection
           loading={exploreLoading}
+          error={exploreError}
           articles={exploreArticles}
           pageLabel={explorePageLabel}
           canPrev={canExplorePrev}

--- a/FrontEnd/src/pages/ScrapPage.jsx
+++ b/FrontEnd/src/pages/ScrapPage.jsx
@@ -7,18 +7,23 @@ import { getScrap } from "../api/getNewsCardAPI";
 import { getMyScrapList } from "../api/scrapAPI";
 import { useAuth } from "../util/AuthContext";
 import { parseApiDate } from "../util/date";
+import { getApiErrorMessage } from "../api/apiClient";
+import ApiErrorMessage from "../components/commons/apiState/ApiErrorMessage";
 
 export default function ScrapPage() {
   const [scrapNews, setScrapNews] = useState([]);
   const [scrapPage, setScrapPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
   const [isScrapped, setIsScrapped] = useState(true);
+  const [scrapError, setScrapError] = useState("");
   const { token } = useAuth();
   const newsPerPage = 12;
 
   useEffect(() => {
     async function fetchScrapNews() {
-      if (token) {
+      setScrapError("");
+      try {
+        if (token) {
         // 로그인: BE DB에서 스크랩 목록 조회
         const data = await getMyScrapList();
         const newTotalPages = Math.ceil(data.length / newsPerPage);
@@ -42,7 +47,7 @@ export default function ScrapPage() {
           };
         });
         setScrapNews(mapped);
-      } else {
+        } else {
         // 비로그인: localStorage → BE /api/scrap
         const storedScrapIds = JSON.parse(
           localStorage.getItem("scrapIds") || "[]",
@@ -67,8 +72,12 @@ export default function ScrapPage() {
         } else {
           setScrapNews([]);
         }
+        }
+        setIsScrapped(true);
+      } catch (error) {
+        setScrapNews([]);
+        setScrapError(getApiErrorMessage(error, "스크랩 목록을 불러오지 못했습니다."));
       }
-      setIsScrapped(true);
     }
 
     fetchScrapNews();
@@ -78,7 +87,9 @@ export default function ScrapPage() {
     <div className={styled["ScrapNews--container"]}>
       <div className={styled["ScrapNews--Newscontainer"]}>
         <div className={styled["ScrapNews--News"]}>
-          {scrapNews.length > 0 ? (
+          {scrapError ? (
+            <ApiErrorMessage message={scrapError} />
+          ) : scrapNews.length > 0 ? (
             <div className={styled["ScrapNews--News__container"]}>
               <div className={styled["ScrapNews--News__items"]}>
                 {scrapNews.map((news) => (

--- a/FrontEnd/src/pages/SearchPage.jsx
+++ b/FrontEnd/src/pages/SearchPage.jsx
@@ -2,10 +2,12 @@ import styled from './MainPage.module.css';
 import SearchContainer from '../components/mainPage/SearchContainer';
 import SearchNews from '../components/mainPage/SearchNews';
 import BlankNews from '../components/mainPage/BlankNews';
+import ApiErrorMessage from '../components/commons/apiState/ApiErrorMessage';
 
 import { useState, useEffect, useCallback } from 'react';
 import { useParams, useLocation, useSearchParams } from "react-router-dom";
 import { getSearch } from '../api/getNewsCardAPI';
+import { getApiErrorMessage } from '../api/apiClient';
 
 function exploreFiltersFromParams(searchParams) {
     const country = searchParams.get("country");
@@ -28,17 +30,24 @@ export default function SearchPage() {
     const [translatedWord, setTranslatedWord] = useState("");
     const [originalWord, setOriginalWord] = useState("");
     const [isLoading, setIsLoading] = useState(false);
+    const [searchError, setSearchError] = useState("");
 
     const handleSearch = useCallback(async (term, exploreFilters = {}) => {
         if (!term.trim()) return;
         setIsLoading(true);
+        setSearchError("");
 
-        const { results, originalText, translatedText } = await getSearch(term, exploreFilters);
-        setSearchResults(results || []);
-        setOriginalWord(originalText || "");
-        setTranslatedWord(translatedText || "");
-
-        setIsLoading(false);
+        try {
+            const { results, originalText, translatedText } = await getSearch(term, exploreFilters);
+            setSearchResults(results || []);
+            setOriginalWord(originalText || "");
+            setTranslatedWord(translatedText || "");
+        } catch (error) {
+            setSearchResults(null);
+            setSearchError(getApiErrorMessage(error, "검색 결과를 불러오지 못했습니다."));
+        } finally {
+            setIsLoading(false);
+        }
     }, []);
 
     const exploreQueryKey = searchParams.toString();
@@ -46,7 +55,7 @@ export default function SearchPage() {
     useEffect(() => {
         if (!keyword) return;
         setSearchTerm(keyword);
-        const filters = exploreFiltersFromParams(searchParams);
+        const filters = exploreFiltersFromParams(new URLSearchParams(exploreQueryKey));
         handleSearch(keyword, filters);
     }, [location.key, keyword, exploreQueryKey, handleSearch]);
 
@@ -56,8 +65,10 @@ export default function SearchPage() {
             <SearchContainer 
                 searchTerm={searchTerm || ""}
             />
-            {isLoading ? ( 
-                <BlankNews message="검색 중입니다..." />  
+            {isLoading ? (
+                <BlankNews message="검색 중입니다..." />
+            ) : searchError ? (
+                <ApiErrorMessage message={searchError} />
             ) : searchResults?.length > 0 ? (
                 <SearchNews 
                     searchTerm={searchTerm} 

--- a/FrontEnd/src/util/AuthContext.jsx
+++ b/FrontEnd/src/util/AuthContext.jsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import { authAPI } from "../api/authAPI";
+import { AUTH_EXPIRED_EVENT } from "../api/apiClient";
 import { clearAnonymousSessionId } from "./anonymousSession.js";
 
 const AuthContext = createContext();
@@ -7,6 +9,15 @@ const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(localStorage.getItem("token") || null);
   const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const handleExpired = () => {
+      setToken(null);
+      setUser(null);
+    };
+    window.addEventListener(AUTH_EXPIRED_EVENT, handleExpired);
+    return () => window.removeEventListener(AUTH_EXPIRED_EVENT, handleExpired);
+  }, []);
 
   // 토큰이 있으면 내 정보 조회
   useEffect(() => {
@@ -39,6 +50,11 @@ export const AuthProvider = ({ children }) => {
   );
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   return useContext(AuthContext);
 }
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -1,0 +1,56 @@
+# Frontend Improvement Work Progress
+
+프론트엔드 개인 검증 작업의 현재 상태와 다음 세션 기준을 기록합니다.
+
+## 작업 절차
+
+`Issue → Branch → 조사 → 계획 → 승인 → 구현 → Build/Lint/API/브라우저 검증 → PR → AI Reviewer → Blocking 확인 → 사용자 승인 → squash merge`
+
+- Issue와 PR 본문은 저장소 템플릿을 읽고 `--body-file`로 작성합니다.
+- Reviewer Agent는 별도 대화에서 PR diff만 검토하고 `## AI Reviewer 검토 결과` 제목으로 comment를 남깁니다.
+- `MERGE_READY`이고 Blocking이 없어도 사용자 승인 후 merge합니다.
+- 구현, 검증 보조 코드와 작업 진척 문서는 가능한 한 하나의 squash commit으로 정리합니다.
+
+## In Progress
+
+없음
+
+## Recently Merged
+
+### #92/#93 Backend API 주소·인증·오류 응답 처리 통합
+
+- 공통 Axios base URL과 JWT 요청 처리를 통합했습니다.
+- 빈 결과로 소실되던 HTTP 오류와 실패 envelope를 화면까지 전달했습니다.
+- 기사·검색·Explore·Trend·Scrap·Chat의 실패 상태를 기존 성공 흐름과 분리했습니다.
+- `401`, `403`, `502`, `503`, `504` Backend 응답을 사용자 상태로 표현할 기반을 마련했습니다.
+- 검증 결과:
+  - `npm run build` 성공
+  - 변경된 JavaScript·JSX 파일 ESLint 성공 (`--max-warnings 0`)
+  - Frontend `5173` proxy를 통한 cursor 기사·상세·공개 스크랩·익명 이력 실제 API 성공
+  - 인증 없이 `/api/user/me` 요청 시 `401` 유지 확인
+  - Backend 중단 시 검색 결과 0건과 연결 실패 UI가 구분되는지 확인
+  - HTTP 200 응답의 `isSuccess: false`도 빈 결과가 아닌 Backend 오류 메시지로 전달
+  - Mock Backend `503` 응답이 기사 요약 영역에 queue 포화 메시지로 표시되는지 확인
+  - 데스크톱 렌더링 및 제한된 모바일 viewport에서 오류 안내가 화면을 침범하지 않는지 확인
+
+- #90/#91: 카드 컴포넌트 날짜 `NaN` 표기 수정
+- #87/#88: 상세 페이지 Perspectives API와 UI 연동
+- #85/#86: 비로그인 Redis 익명 세션 기반 기사 대화 Context 연동
+- #83/#84: 검색 API에 국가·카테고리·날짜 탐색 조건 연동
+- #79/#80: 기사 Explore API와 커서 탐색 UI 연동
+- #77/#78: 최신 기사 목록을 cursor pagination으로 전환
+- #71/#72: 로그인 DB·비로그인 localStorage 스크랩 분기 연동
+- #69/#70: 로그인 사용자 채팅 히스토리 조회 연동
+- #67/#68: 기사 AI SSE 질의와 스트리밍 UI 연동
+
+## Next Candidates
+
+1. 기사 요약·SSE 정상 종료와 `502/503/504` 실패 상태별 재시도 UX 검증
+2. 핵심 사용자 흐름 브라우저 회귀 테스트와 Frontend CI 구축
+3. 기존 전체 ESLint 오류 기준선 정리 (`17 errors / 4 warnings`, #92 변경 파일 제외)
+
+## Guardrail
+
+- 현재 Backend 규모에서 필요한 연동·회귀 방지부터 처리합니다.
+- React Query, 전역 상태 관리, 대규모 API 계층 재작성은 실제 중복과 상태 복잡성이 근거로 확인되기 전까지 도입하지 않습니다.
+- 번들 분할과 렌더링 최적화는 측정 결과가 없는 상태에서 선행하지 않습니다.


### PR DESCRIPTION
## 📌 작업 내용

- 공개·인증 API가 동일한 `VITE_APP_API` base URL을 사용하도록 Axios client를 통합했습니다.
- JWT 요청 interceptor와 `401` 인증 만료 event를 연결해 Frontend 인증 상태를 함께 정리합니다.
- API 실패를 빈 배열·`null`로 변환하지 않고 `status`, `message`, `payload`를 보존하는 `ApiRequestError`로 전달합니다.
- 검색·Explore·기사 목록·상세·Perspectives·Trend·Scrap·Chat 화면에서 빈 결과와 API 실패 상태를 분리했습니다.
- `401`, `403`, `502`, `503`, `504`의 Backend 메시지를 공통 오류 안내 UI로 표시합니다.
- 프론트 개선 작업 절차와 #92 검증 근거를 `WORK_PROGRESS.md`에 함께 기록했습니다.

## ✅ 체크리스트

- [x] `npm run build` 성공
- [x] 변경 JavaScript·JSX ESLint 성공 (`--max-warnings 0`)
- [x] Frontend `5173` proxy를 통한 Backend 실제 API 연동 확인
- [x] 미인증 사용자 API `401` 응답 유지 확인
- [x] Backend 중단 시 빈 검색 결과와 연결 실패 UI 분리 확인
- [x] Mock Backend `503` queue 포화 메시지 렌더링 확인
- [x] 데스크톱·제한된 모바일 viewport 렌더링 확인

## 🔎 검증 메모

- 실제 API: cursor 기사, 기사 상세, 공개 스크랩, 익명 채팅 이력
- Mock API: 유료 Gemini 호출 없이 기사 요약 `503 Service Unavailable` 재현
- 저장소 전체 lint에는 이번 변경과 무관한 기존 `17 errors / 4 warnings`가 남아 있으며 후속 Issue 후보로 기록했습니다.
- 기존 번들 크기 경고와 dependency 취약점은 이번 API 연동 범위에 포함하지 않았습니다.

## 🔗 관련 이슈

Closes #92
