### PR TITLE
🐛 [FIX/#94] AI 요약·질의 종료 및 실패 재시도 UX 연동

### DIFF
--- a/FrontEnd/src/api/detailsAPI.js
+++ b/FrontEnd/src/api/detailsAPI.js
@@ -39,8 +39,10 @@ export const getNewsDetailsAsk = (
     const eventSource = new EventSource(url);
 
     let previousText = "";
+    let settled = false;
 
     eventSource.onmessage = (event) => {
+        if (settled) return;
         const newText = event.data;
         const newChunk = newText.slice(previousText.length);
         previousText = newText;
@@ -48,15 +50,22 @@ export const getNewsDetailsAsk = (
     };
 
     eventSource.onerror = (error) => {
+        if (settled) return;
+        settled = true;
         console.error("SSE 연결 오류:", error);
         eventSource.close();
         if (onError) onError(error);
     };
 
     eventSource.addEventListener("end", () => {
+        if (settled) return;
+        settled = true;
         eventSource.close();
         if (onComplete) onComplete();
     });
 
-    return () => eventSource.close();
+    return () => {
+        settled = true;
+        eventSource.close();
+    };
 };

--- a/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
+++ b/FrontEnd/src/components/detailsPage/ArticleDetail.jsx
@@ -29,6 +29,7 @@ export default function ArticleDetail({
   isLoading,
   isSummaryLoading,
   summaryError,
+  onSummaryRetry,
 }) {
   const articleId = Number(id);
   const { title, author, sourceName, publishedAt, viewCount, urlToImage } =
@@ -241,7 +242,7 @@ export default function ArticleDetail({
           visible={true}
         />
       ) : summaryError ? (
-        <ApiErrorMessage message={summaryError} />
+        <ApiErrorMessage message={summaryError} onRetry={onSummaryRetry} />
       ) : content ? (
         <div className={styles.content}>
           <ReactMarkdown>{translatedMarkdown}</ReactMarkdown>
@@ -269,4 +270,5 @@ ArticleDetail.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   isSummaryLoading: PropTypes.bool.isRequired,
   summaryError: PropTypes.string,
+  onSummaryRetry: PropTypes.func.isRequired,
 };

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import PropTypes from "prop-types";
 import styles from "./Chatbot.module.css";
-import { Send } from "lucide-react";
+import { RotateCcw, Send } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { getNewsDetailsAsk } from "../../api/detailsAPI.js";
 import {
@@ -21,9 +21,12 @@ export default function Chatbot({ articleId }) {
   const [input, setInput] = useState("");
   const [messages, setMessages] = useState([]);
   const [isStreaming, setIsStreaming] = useState(false);
+  const [activeResponseId, setActiveResponseId] = useState(null);
   const [historyError, setHistoryError] = useState("");
   const chatRef = useRef(null);
   const closeEventSourceRef = useRef(null);
+  const requestSequenceRef = useRef(0);
+  const responseSequenceRef = useRef(0);
 
   const { language } = useLanguage();
   const { token } = useAuth();
@@ -100,58 +103,113 @@ export default function Chatbot({ articleId }) {
   }, [articleId, language, token]);
 
   useEffect(() => {
+    setIsStreaming(false);
+    setActiveResponseId(null);
     return () => {
-      if (closeEventSourceRef.current) closeEventSourceRef.current();
+      requestSequenceRef.current += 1;
+      if (closeEventSourceRef.current) {
+        closeEventSourceRef.current();
+        closeEventSourceRef.current = null;
+      }
     };
-  }, []);
+  }, [articleId]);
 
-  const handleSend = () => {
-    if (!input.trim() || isStreaming) return;
+  const closeCurrentStream = () => {
+    if (!closeEventSourceRef.current) return;
+    closeEventSourceRef.current();
+    closeEventSourceRef.current = null;
+  };
 
-    const userText = input;
-    const newMessages = [...messages, { type: "user", text: userText }];
-    setMessages([...newMessages, { type: "bot", text: "" }]);
-    setInput("");
+  const updateResponse = (responseId, updater) => {
+    setMessages((prev) =>
+      prev.map((message) =>
+        message.id === responseId ? updater(message) : message,
+      ),
+    );
+  };
+
+  const startRequest = (question, responseId) => {
+    closeCurrentStream();
+    const requestSequence = requestSequenceRef.current + 1;
+    requestSequenceRef.current = requestSequence;
     setIsStreaming(true);
+    setActiveResponseId(responseId);
+
+    const finishRequest = () => {
+      if (requestSequenceRef.current !== requestSequence) return false;
+      closeEventSourceRef.current = null;
+      setIsStreaming(false);
+      setActiveResponseId(null);
+      return true;
+    };
+
+    const failRequest = () => {
+      if (!finishRequest()) return;
+      updateResponse(responseId, (message) => ({
+        ...message,
+        fetchError: true,
+        retryQuestion: question,
+      }));
+    };
 
     const anonymousSessionId = token ? null : getOrCreateAnonymousSessionId();
 
-    const close = getNewsDetailsAsk(
-      articleId,
-      userText,
-      (chunk) => {
-        setMessages((prev) => {
-          const updated = [...prev];
-          updated[updated.length - 1] = {
-            ...updated[updated.length - 1],
-            text: updated[updated.length - 1].text + chunk,
-          };
-          return updated;
-        });
-      },
-      () => {
-        setIsStreaming(false);
-      },
-      (error) => {
-        console.error("스트리밍 에러:", error);
-        setIsStreaming(false);
-        setMessages((prev) => {
-          const updated = [...prev];
-          if (updated[updated.length - 1].text === "") {
-            updated[updated.length - 1] = {
-              type: "bot",
-              text: "",
-              fetchError: true,
-            };
-          }
-          return updated;
-        });
-      },
-      token,
-      anonymousSessionId,
-    );
+    try {
+      const close = getNewsDetailsAsk(
+        articleId,
+        question,
+        (chunk) => {
+          if (requestSequenceRef.current !== requestSequence) return;
+          updateResponse(responseId, (message) => ({
+            ...message,
+            text: message.text + chunk,
+          }));
+        },
+        finishRequest,
+        (error) => {
+          console.error("스트리밍 에러:", error);
+          failRequest();
+        },
+        token,
+        anonymousSessionId,
+      );
 
-    closeEventSourceRef.current = close;
+      closeEventSourceRef.current = close;
+    } catch (error) {
+      console.error("SSE 연결 생성 오류:", error);
+      failRequest();
+    }
+  };
+
+  const handleSend = () => {
+    const question = input.trim();
+    if (!question || isStreaming) return;
+
+    const responseId = `stream-${responseSequenceRef.current + 1}`;
+    responseSequenceRef.current += 1;
+    setMessages((prev) => [
+      ...prev,
+      { type: "user", text: question },
+      {
+        id: responseId,
+        type: "bot",
+        text: "",
+        fetchError: false,
+        retryQuestion: question,
+      },
+    ]);
+    setInput("");
+    startRequest(question, responseId);
+  };
+
+  const handleRetry = (message) => {
+    if (isStreaming || !message.id || !message.retryQuestion) return;
+    updateResponse(message.id, (current) => ({
+      ...current,
+      text: "",
+      fetchError: false,
+    }));
+    startRequest(message.retryQuestion, message.id);
   };
 
   useEffect(() => {
@@ -186,41 +244,48 @@ export default function Chatbot({ articleId }) {
               </div>
             );
           }
-          if (msg.type === "bot" && msg.fetchError) {
-            return (
-              <div key={index} className={styles.botMessage}>
-                <TranslatedText text="응답을 가져오는 데 실패했습니다." />
-              </div>
-            );
-          }
           return (
             <div
-              key={index}
+              key={msg.id ?? index}
               className={
                 msg.type === "bot" ? styles.botMessage : styles.userMessage
               }
             >
               {msg.type === "bot" ? (
-                <div className={styles.markdown}>
-                  <ReactMarkdown>{msg.text}</ReactMarkdown>
-                </div>
+                <>
+                  {msg.text && (
+                    <div className={styles.markdown}>
+                      <ReactMarkdown>{msg.text}</ReactMarkdown>
+                    </div>
+                  )}
+                  {msg.id === activeResponseId && !msg.text && !msg.fetchError && (
+                    <span className={styles.typingIndicator}>
+                      <span />
+                      <span />
+                      <span />
+                    </span>
+                  )}
+                  {msg.fetchError && (
+                    <div className={styles.streamError} role="alert">
+                      <TranslatedText text="응답 연결이 중단되었습니다." />
+                      <button
+                        type="button"
+                        onClick={() => handleRetry(msg)}
+                        disabled={isStreaming}
+                        title="같은 질문 다시 시도"
+                      >
+                        <RotateCcw size={15} aria-hidden />
+                        <TranslatedText text="다시 시도" />
+                      </button>
+                    </div>
+                  )}
+                </>
               ) : (
                 msg.text
               )}
             </div>
           );
         })}
-        {isStreaming &&
-          messages[messages.length - 1]?.text === "" &&
-          !messages[messages.length - 1]?.fetchError && (
-            <div className={styles.botMessage}>
-              <span className={styles.typingIndicator}>
-                <span />
-                <span />
-                <span />
-              </span>
-            </div>
-          )}
       </div>
       <div className={styles.chatInput}>
         <input
@@ -231,8 +296,14 @@ export default function Chatbot({ articleId }) {
           disabled={isStreaming}
           onKeyDown={(e) => e.key === "Enter" && handleSend()}
         />
-        <button onClick={handleSend} disabled={isStreaming}>
-          <Send size={20} />
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={isStreaming}
+          title="질문 보내기"
+          aria-label="질문 보내기"
+        >
+          <Send size={20} aria-hidden />
         </button>
       </div>
     </div>

--- a/FrontEnd/src/components/detailsPage/Chatbot.module.css
+++ b/FrontEnd/src/components/detailsPage/Chatbot.module.css
@@ -137,6 +137,42 @@
     font-size: 0.9em;
 }
 
+.streamError {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    color: #a22a2a;
+    font-size: 13px;
+}
+
+.markdown + .streamError {
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid #d8b6b6;
+}
+
+.streamError button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border: 1px solid #a22a2a;
+    border-radius: 6px;
+    padding: 5px 8px;
+    color: #8f2020;
+    background: #fff;
+    cursor: pointer;
+}
+
+.streamError button:hover:not(:disabled) {
+    background: #fff1f1;
+}
+
+.streamError button:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+}
+
 .chatInput input:disabled {
     background: #f0f0f0;
     cursor: not-allowed;

--- a/FrontEnd/src/pages/DetailsPage.jsx
+++ b/FrontEnd/src/pages/DetailsPage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { getNewsDetails, getNewsDetailsSummary } from "../api/detailsAPI";
 import styles from "./DetailsPage.module.css";
@@ -19,6 +19,23 @@ export default function DetailsPage() {
   const [detailError, setDetailError] = useState("");
   const [summaryError, setSummaryError] = useState("");
 
+  const fetchSummary = useCallback(async () => {
+    if (!id) return;
+
+    setIsSummaryLoading(true);
+    setSummaryError("");
+    try {
+      const summaryRes = await getNewsDetailsSummary(id);
+      if (summaryRes && typeof summaryRes.data === "string") {
+        setContent(summaryRes.data);
+      }
+    } catch (error) {
+      setSummaryError(getApiErrorMessage(error, "기사 요약을 불러오지 못했습니다."));
+    } finally {
+      setIsSummaryLoading(false);
+    }
+  }, [id]);
+
   useEffect(() => {
     const fetchDetail = async () => {
       setIsLoading(true);
@@ -36,26 +53,11 @@ export default function DetailsPage() {
       }
     };
 
-    const fetchSummary = async () => {
-      setIsSummaryLoading(true);
-      setSummaryError("");
-      try {
-        const summaryRes = await getNewsDetailsSummary(id);
-        if (summaryRes && typeof summaryRes.data === "string") {
-          setContent(summaryRes.data);
-        }
-      } catch (error) {
-        setSummaryError(getApiErrorMessage(error, "기사 요약을 불러오지 못했습니다."));
-      } finally {
-        setIsSummaryLoading(false);
-      }
-    };
-
     if (id) {
       fetchDetail();
       fetchSummary();
     }
-  }, [id]);
+  }, [id, fetchSummary]);
 
   return (
     <div className={styles.detailsPage}>
@@ -72,6 +74,7 @@ export default function DetailsPage() {
                 isLoading={isLoading}
                 isSummaryLoading={isSummaryLoading}
                 summaryError={summaryError}
+                onSummaryRetry={fetchSummary}
               />
               <PerspectivesSection articleId={id} />
               <Chatbot articleId={id} />

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -13,9 +13,36 @@
 
 ## In Progress
 
-없음
+- 없음
 
 ## Recently Merged
+
+### #94/#95 Backend AI 요약·질의 종료 및 실패 재시도 UX 연동
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/issues/94
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/pull/95
+- Backend 연동:
+  - Backend #245/PR #246에서 추가한 named SSE `end` 이벤트를 정상 완료 신호로 소비합니다.
+  - Backend 요약 API의 `502/503/504` 메시지를 유지하면서 사용자가 직접 재시도할 수 있게 연결합니다.
+- 연동 중 발견한 Frontend 문제:
+  - 완료·오류 뒤 EventSource 참조가 정리되지 않았습니다.
+  - 요약 오류 UI에 재시도 동작이 없었습니다.
+  - SSE 실패 질문이 답변 상태에 보존되지 않아 같은 질문을 다시 입력해야 했습니다.
+- 해결 범위:
+  - SSE 완료·오류·재요청의 단일 종료 처리와 오래된 callback 차단
+  - 요약 수동 재시도와 실패 질문의 위치 기반 재시도
+  - Mock API/SSE 브라우저 검증과 가능한 경우 실제 Backend 연동 확인
+- 검증 결과:
+  - Mock 요약 `503 → 수동 재시도 200`과 오류 UI 제거 확인
+  - Mock SSE `503 → 동일 질문 재시도 → data chunk → event: end` 정상 완료 확인
+  - 재시도 후 사용자 질문 DOM 1건 유지, 입력 버튼 재활성화, 실패 버튼 제거 확인
+  - `npm run build`와 변경 JavaScript·JSX ESLint 통과
+  - 전체 `npm run lint`는 변경 파일과 무관한 기존 기준선 `17 errors / 4 warnings`로 실패
+  - Docker Desktop의 `desktop-linux` context에서 MySQL·Redis를 기동하고 Frontend `5173` proxy → Backend `8080` → 실제 DB/Redis 경로 확인
+  - 실제 기사 상세·요약·최근 기사 응답이 화면 DOM에 렌더링되는지 확인
+  - Gemini만 로컬 Mock으로 대체한 실제 Backend SSE에서 `data` → named `event: end`, `data: completed` wire 응답 확인
+  - 동일 익명 세션의 Redis 이력 조회에서 질의·응답 저장 결과 확인
+- 범위 제외: 신규 AI 기능, 자동 무한 재시도, React Query·전역 상태, 신규 SSE 라이브러리와 Backend API 추가 변경
 
 ### #92/#93 Backend API 주소·인증·오류 응답 처리 통합
 


### PR DESCRIPTION
## 📌 작업 내용

### Backend 개선사항 연동
- Backend #245/PR #246의 named SSE `event: end`, `data: completed`를 정상 완료 신호로 소비합니다.
- 기사 요약 API의 Backend `502/503/504` 메시지를 유지하면서 오류 영역에 수동 재시도를 연결했습니다.

### 연동 중 발견한 Frontend 문제와 해결
- 완료·오류·재요청 시 EventSource 참조가 남던 lifecycle을 settled guard와 명시적 close/ref 정리로 통합했습니다.
- 이전 요청 callback이 새 요청 상태를 덮지 않도록 request sequence로 오래된 callback을 차단했습니다.
- SSE 실패 질문과 응답 ID를 보존해 사용자 메시지를 중복 추가하지 않고 실패한 답변 위치에서 같은 질문을 재시도합니다.
- 부분 응답 뒤 연결이 끊겨도 받은 텍스트를 남기고 실패·재시도 상태를 함께 표시합니다.
- 요약 요청 함수를 재사용 가능하게 분리해 공통 `ApiErrorMessage`의 재시도 버튼과 연결했습니다.

### 검증 결과
- `npm.cmd run build` 성공. 기존 500kB bundle warning만 유지됩니다.
- 변경 JavaScript·JSX 파일 ESLint `--max-warnings 0` 성공
- Mock HTTP/SSE headless Edge E2E:
  - 요약 `503 → 수동 재시도 200`과 오류 UI 제거
  - SSE `503 → 동일 질문 재시도 → data chunk → event: end` 정상 완료
  - 사용자 질문 DOM 1건 유지, 입력 버튼 재활성화, 실패 버튼 제거
- 실제 Backend 연동 E2E:
  - Docker MySQL·Redis와 Backend `8080`, Frontend `5173` proxy 연결
  - 실제 DB 기사 상세·요약·최근 기사 응답의 화면 렌더링 확인
  - Gemini만 로컬 Mock으로 대체하고 실제 Backend SSE의 `data` → named `event: end`, `data: completed` 응답 확인
  - 동일 익명 세션 Redis 이력에서 질의·응답 저장 확인
- 전체 `npm run lint`는 이번 변경과 무관한 기존 기준선 `17 errors / 4 warnings`로 실패합니다.

### 범위 제외
- 신규 AI 기능, 자동 무한 재시도, React Query·전역 상태, 신규 SSE 라이브러리, Backend API 추가 변경

## ✅ 체크리스트
- [x] 로컬 build와 변경 파일 lint 확인 완료
- [x] Backend #245/PR #246 종료 계약을 Mock 브라우저와 실제 Backend SSE 양쪽에서 확인
- [x] 실제 Frontend proxy → Backend → MySQL/Redis 연동 확인
- [x] 구현·검증 결과를 `docs/frontend-improvement/WORK_PROGRESS.md`에 기록

## 🔗 관련 이슈
Closes #94

Backend: SKU-GlobalTimes/GlobalTimes_BeSide#245, SKU-GlobalTimes/GlobalTimes_BeSide#246

## 💬 리뷰 요청사항
- 정상 `end`, 연결 오류, 수동 close가 중복 callback 없이 한 번만 상태를 종료하는지 확인해주세요.
- 실패 질문 재시도가 사용자 질문을 중복 추가하거나 다른 답변을 덮지 않는지 확인해주세요.
- 요약 재시도가 Backend 오류 message를 유지하며 성공 후 오류 상태를 제거하는지 확인해주세요.
