### PR TITLE
💻 [TEST/#96] Frontend-Backend 실제 연동 E2E 자동화

### DIFF
--- a/.github/workflows/full-stack-e2e.yml
+++ b/.github/workflows/full-stack-e2e.yml
@@ -1,0 +1,66 @@
+name: Full Stack E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      backend_ref:
+        description: Backend branch, tag, or commit SHA
+        required: true
+        default: develop
+        type: string
+  pull_request:
+    types: [labeled]
+
+jobs:
+  full-stack-e2e:
+    if: github.event_name == 'workflow_dispatch' || github.event.label.name == 'full-stack-e2e'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout Frontend
+        uses: actions/checkout@v6
+
+      - name: Checkout Backend
+        uses: actions/checkout@v6
+        with:
+          repository: SKU-GlobalTimes/GlobalTimes_BeSide
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.backend_ref || 'develop' }}
+          path: _backend
+
+      - name: Set up Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: FrontEnd/package-lock.json
+
+      - name: Install Frontend dependencies
+        working-directory: FrontEnd
+        run: npm ci
+
+      - name: Install Playwright browser
+        working-directory: FrontEnd
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Frontend-Backend E2E
+        shell: pwsh
+        run: ./scripts/run-full-stack-e2e.ps1 -BackendPath "${{ github.workspace }}/_backend" -SkipBrowserInstall
+
+      - name: Upload E2E evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: full-stack-e2e-${{ github.run_id }}
+          if-no-files-found: warn
+          retention-days: 14
+          path: |
+            FrontEnd/playwright-report
+            FrontEnd/test-results
+            FrontEnd/e2e-artifacts

--- a/FrontEnd/.eslintrc.cjs
+++ b/FrontEnd/.eslintrc.cjs
@@ -18,4 +18,10 @@ module.exports = {
       { allowConstantExport: true },
     ],
   },
+  overrides: [
+    {
+      files: ['playwright.config.js', 'e2e/**/*.js'],
+      env: { node: true, es2022: true },
+    },
+  ],
 }

--- a/FrontEnd/.gitignore
+++ b/FrontEnd/.gitignore
@@ -11,6 +11,9 @@ node_modules
 dist
 dist-ssr
 *.local
+playwright-report
+test-results
+e2e-artifacts
 
 # Editor directories and files
 .vscode/*

--- a/FrontEnd/README.md
+++ b/FrontEnd/README.md
@@ -17,3 +17,7 @@
 |🚀|Deploy|Deploying stuff|
 |🔄️|Rename|파일 혹은 폴더명을 수정하거나 옮기는 작업만인 경우|
 |🪚|Remove|파일을 삭제하는 작업만 수행한 경우|
+
+### Full-stack E2E
+
+Frontend, Backend, MySQL, Redis와 Playwright 브라우저를 한 번에 실행하는 방법은 [Full-stack E2E 문서](../docs/frontend-improvement/full-stack-e2e.md)를 참고합니다.

--- a/FrontEnd/e2e/docker-compose.e2e.yml
+++ b/FrontEnd/e2e/docker-compose.e2e.yml
@@ -1,0 +1,24 @@
+services:
+  mysql:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: e2epw
+      MYSQL_DATABASE: globaltimes
+      TZ: Asia/Seoul
+    ports:
+      - "13306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root", "-pe2epw"]
+      interval: 3s
+      timeout: 3s
+      retries: 40
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "16379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 3s
+      timeout: 3s
+      retries: 40

--- a/FrontEnd/e2e/fixtures/full-stack-smoke.sql
+++ b/FrontEnd/e2e/fixtures/full-stack-smoke.sql
@@ -1,0 +1,55 @@
+INSERT INTO source (source_id, source_api_id, source_name)
+VALUES (990096, 'e2e-source', 'E2E Press')
+ON DUPLICATE KEY UPDATE source_name = VALUES(source_name);
+
+INSERT INTO article (
+  article_id, author, category, content, country, crawled_content,
+  description, published_at, summary, title, url, url_to_image,
+  view_count, source_id, language
+) VALUES (
+  990096,
+  'E2E Author',
+  'technology',
+  'E2E article content.',
+  'KR',
+  'This article verifies real frontend and backend integration automation.',
+  'Article description for the full-stack E2E smoke test.',
+  '2026-08-11 12:00:00',
+  'This summary passed through the real backend and database.',
+  'Full-stack E2E verification article',
+  'https://example.com/e2e/full-stack-96',
+  '',
+  0,
+  990096,
+  'ko'
+)
+ON DUPLICATE KEY UPDATE
+  crawled_content = VALUES(crawled_content),
+  summary = VALUES(summary),
+  title = VALUES(title);
+
+INSERT INTO article (
+  article_id, author, category, content, country, crawled_content,
+  description, published_at, summary, title, url, url_to_image,
+  view_count, source_id, language
+) VALUES (
+  990097,
+  'E2E Author',
+  'technology',
+  'Second E2E article content.',
+  'US',
+  'This second article verifies client-side detail navigation.',
+  'Second article description for the full-stack E2E smoke test.',
+  '2026-08-11 11:00:00',
+  'The second article summary passed through the real backend.',
+  'Second full-stack E2E article',
+  'https://example.com/e2e/full-stack-97',
+  '',
+  0,
+  990096,
+  'en'
+)
+ON DUPLICATE KEY UPDATE
+  crawled_content = VALUES(crawled_content),
+  summary = VALUES(summary),
+  title = VALUES(title);

--- a/FrontEnd/e2e/full-stack.spec.js
+++ b/FrontEnd/e2e/full-stack.spec.js
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+const ARTICLE_ID = 990_096;
+const ARTICLE_TITLE = "Full-stack E2E verification article";
+const ARTICLE_SUMMARY = "This summary passed through the real backend and database.";
+const SECOND_ARTICLE_ID = 990_097;
+const SECOND_ARTICLE_TITLE = "Second full-stack E2E article";
+const QUESTION = "What is the key point of this article?";
+const ANSWER = "Backend SSE integration verified";
+const SESSION_ID = "00000000-0000-4000-8000-000000000096";
+
+test("기사 상세부터 익명 SSE 저장까지 실제 Backend 경로를 검증한다", async ({ page }) => {
+  await page.addInitScript(([key, value]) => {
+    window.localStorage.setItem(key, value);
+  }, ["globalTimes_anonymous_chat_session_id", SESSION_ID]);
+
+  // UI translation is outside this E2E scope; preserve English fixture text without a real API call.
+  await page.route("https://translation.googleapis.com/**", async (route) => {
+    const body = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: { translations: [{ translatedText: body.q }] },
+      }),
+    });
+  });
+
+  // Deliver the real empty-history response late to reproduce the initialization race deterministically.
+  await page.route(`**/api/ai/${ARTICLE_ID}/ask/history?*`, async (route) => {
+    const response = await route.fetch();
+    const status = response.status();
+    const headers = response.headers();
+    const body = await response.body();
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    await route.fulfill({ status, headers, body });
+  });
+
+  // Perspectives 품질은 별도 Backend 검증 범위다. 이 smoke test는 상세·요약·질의 경로에 집중한다.
+  await page.route("**/api/news/*/perspectives", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ isSuccess: true, message: "success", data: {} }),
+    });
+  });
+
+  const detailResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/news/detail?id=${ARTICLE_ID}`),
+  );
+  const summaryResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/ai/${ARTICLE_ID}/summary`),
+  );
+
+  await page.goto(`/detail/${ARTICLE_ID}`);
+
+  const [detailResponse, summaryResponse] = await Promise.all([
+    detailResponsePromise,
+    summaryResponsePromise,
+  ]);
+
+  expect(detailResponse.status()).toBe(200);
+  expect(summaryResponse.status()).toBe(200);
+  expect((await detailResponse.json()).data.newsDetail.title).toBe(ARTICLE_TITLE);
+  expect((await summaryResponse.json()).data).toBe(ARTICLE_SUMMARY);
+
+  await expect(page.getByRole("heading", { name: ARTICLE_TITLE })).toBeVisible();
+  await expect(page.getByText(ARTICLE_SUMMARY, { exact: true })).toBeVisible();
+
+  const input = page.getByPlaceholder("질문을 입력하세요...");
+  const sendButton = page.getByRole("button", { name: "질문 보내기" });
+  await input.fill(QUESTION);
+
+  const askResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/ai/${ARTICLE_ID}/ask?`),
+  );
+  await sendButton.click();
+
+  const askResponse = await askResponsePromise;
+  expect(askResponse.status()).toBe(200);
+  expect(askResponse.headers()["content-type"]).toContain("text/event-stream");
+  await expect(page.getByText(ANSWER, { exact: true })).toBeVisible();
+  await expect(sendButton).toBeEnabled();
+  await expect(page.getByText(QUESTION, { exact: true })).toHaveCount(1);
+
+  const historyResponse = await page.request.get(
+    `/api/ai/${ARTICLE_ID}/ask/history`,
+    { params: { anonymousSession: SESSION_ID } },
+  );
+  expect(historyResponse.status()).toBe(200);
+  const history = await historyResponse.json();
+  expect(history.data).toEqual([
+    expect.objectContaining({ question: QUESTION, answer: ANSWER }),
+  ]);
+
+  const secondDetailResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/news/detail?id=${SECOND_ARTICLE_ID}`),
+  );
+  await page.evaluate((articleId) => {
+    window.history.pushState({}, "", `/detail/${articleId}`);
+    window.dispatchEvent(new PopStateEvent("popstate"));
+  }, SECOND_ARTICLE_ID);
+
+  expect((await secondDetailResponsePromise).status()).toBe(200);
+  await expect(page.getByRole("heading", { name: SECOND_ARTICLE_TITLE })).toBeVisible();
+  await expect(page.getByText(QUESTION, { exact: true })).toHaveCount(0);
+});

--- a/FrontEnd/e2e/support/gemini-mock.cjs
+++ b/FrontEnd/e2e/support/gemini-mock.cjs
@@ -1,0 +1,29 @@
+const http = require("http");
+
+const port = Number(process.env.GEMINI_MOCK_PORT ?? 19099);
+
+http.createServer((request, response) => {
+  request.resume();
+
+  if (request.url.includes(":streamGenerateContent")) {
+    response.writeHead(200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    response.write(`data: ${JSON.stringify({
+      candidates: [{
+        content: { parts: [{ text: "Backend SSE integration verified" }] },
+      }],
+    })}\n\n`);
+    response.end();
+    return;
+  }
+
+  response.writeHead(200, { "Content-Type": "application/json" });
+  response.end(JSON.stringify({
+    candidates: [{ content: { parts: [{ text: "Mock summary" }] } }],
+  }));
+}).listen(port, "127.0.0.1", () => {
+  console.log(`Gemini mock listening on ${port}`);
+});

--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -28,6 +28,7 @@
         "world-countries": "^5.1.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
         "@vitejs/plugin-react": "^4.2.1",
@@ -952,6 +953,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5169,6 +5186,53 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/point-in-polygon-hao": {
       "version": "1.2.4",

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "e2e": "playwright test",
+    "e2e:report": "playwright show-report"
   },
   "dependencies": {
     "aos": "^2.3.4",
@@ -30,6 +32,7 @@
     "world-countries": "^5.1.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",
     "@vitejs/plugin-react": "^4.2.1",

--- a/FrontEnd/playwright.config.js
+++ b/FrontEnd/playwright.config.js
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  outputDir: "./test-results",
+  fullyParallel: false,
+  workers: 1,
+  retries: process.env.CI ? 1 : 0,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [
+    ["line"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+  ],
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? "http://127.0.0.1:5173",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/FrontEnd/src/components/detailsPage/Chatbot.jsx
+++ b/FrontEnd/src/components/detailsPage/Chatbot.jsx
@@ -27,6 +27,7 @@ export default function Chatbot({ articleId }) {
   const closeEventSourceRef = useRef(null);
   const requestSequenceRef = useRef(0);
   const responseSequenceRef = useRef(0);
+  const conversationRevisionRef = useRef(0);
 
   const { language } = useLanguage();
   const { token } = useAuth();
@@ -36,6 +37,10 @@ export default function Chatbot({ articleId }) {
   // 인사말 번역 + 로그인·비로그인 이전 대화 내역 (비로그인: Redis + anonymousSession)
   useEffect(() => {
     let cancelled = false;
+    const initialConversationRevision = conversationRevisionRef.current;
+
+    setMessages([]);
+    setHistoryError("");
 
     const init = async () => {
       const translatedGreeting = await fetchTranslatedText(
@@ -46,9 +51,11 @@ export default function Chatbot({ articleId }) {
         "질문을 입력하세요...",
         language,
       );
-      if (cancelled) return;
+      if (
+        cancelled ||
+        conversationRevisionRef.current !== initialConversationRevision
+      ) return;
       setPlaceholder(translatedPlaceholder);
-      setHistoryError("");
 
       const buildFromHistory = (history, greeting) => {
         if (!history?.length) {
@@ -76,21 +83,33 @@ export default function Chatbot({ articleId }) {
       try {
         if (token && articleId) {
           const history = await getChatsByArticle(articleId);
-          if (cancelled) return;
+          if (
+            cancelled ||
+            conversationRevisionRef.current !== initialConversationRevision
+          ) return;
           setMessages(buildFromHistory(history, translatedGreeting));
         } else if (articleId) {
           const sessionId = getOrCreateAnonymousSessionId();
           const history = sessionId
             ? await getAnonymousChatsByArticle(articleId, sessionId)
             : [];
-          if (cancelled) return;
+          if (
+            cancelled ||
+            conversationRevisionRef.current !== initialConversationRevision
+          ) return;
           setMessages(buildFromHistory(history, translatedGreeting));
         } else {
-          if (cancelled) return;
+          if (
+            cancelled ||
+            conversationRevisionRef.current !== initialConversationRevision
+          ) return;
           setMessages([{ type: "bot", text: translatedGreeting }]);
         }
       } catch (error) {
-        if (cancelled) return;
+        if (
+          cancelled ||
+          conversationRevisionRef.current !== initialConversationRevision
+        ) return;
         setMessages([{ type: "bot", text: translatedGreeting }]);
         setHistoryError(getApiErrorMessage(error, "이전 대화를 불러오지 못했습니다."));
       }
@@ -187,6 +206,7 @@ export default function Chatbot({ articleId }) {
 
     const responseId = `stream-${responseSequenceRef.current + 1}`;
     responseSequenceRef.current += 1;
+    conversationRevisionRef.current += 1;
     setMessages((prev) => [
       ...prev,
       { type: "user", text: question },

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -13,7 +13,39 @@
 
 ## In Progress
 
-- 없음
+### #96 Frontend-Backend 실제 연동 Playwright 자동화
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/issues/96
+- Branch: `test/96-full-stack-playwright-e2e`
+- 목적: 수동 Frontend `5173` → Backend `8080` → MySQL/Redis 검증을 로컬 한 명령과 GitHub Runner에서 재현합니다.
+- 실제 경로:
+  - 별도 MySQL `13306`·Redis `16379`와 일회성 volume
+  - Backend Flyway migration과 기사 fixture
+  - 상세·요약 응답, 익명 AI SSE와 Redis 이력 저장·조회
+- Mock 경계: Gemini, 브라우저 번역과 범위 밖 Perspectives만 대체하고 실제 외부 API·OAuth·수집 scheduler는 호출하지 않습니다.
+- 연동 중 발견한 Frontend 문제:
+  - 초기 채팅 이력 응답이 늦게 도착하면 이미 시작된 질문과 SSE 답변 상태를 덮어쓸 수 있었습니다.
+  - 사용자가 대화를 시작한 뒤에는 늦은 초기화 결과가 현재 메시지를 교체하지 않도록 보강했습니다.
+  - Reviewer 검토에서 기사 전환 시 이전 기사의 메시지가 새 history 반영을 막는 회귀를 발견했습니다.
+  - 초기화 시점과 질문 시작 시점의 conversation revision을 비교해 늦은 동일 초기화 응답만 폐기하고, 기사·언어·인증 identity 변경 시에는 새 history를 반영하도록 보완했습니다.
+- E2E 격리 보완:
+  - Compose project 이름을 실행 PID별로 분리했습니다.
+  - 이 실행이 `docker compose up`을 시작한 경우에만 동일 project의 container와 volume을 cleanup하도록 ownership guard를 적용했습니다.
+  - 새로고침 없는 기사 A→B 이동 시 이전 질문이 남지 않는 Playwright 회귀 시나리오를 추가했습니다.
+- 자동화:
+  - 로컬 `scripts/run-full-stack-e2e.cmd`
+  - GitHub Actions `workflow_dispatch` 및 `full-stack-e2e` label 기반 opt-in PR 실행
+  - 실패 시 report·screenshot·video·trace와 서버·컨테이너 로그 artifact 보관
+- 로컬 검증:
+  - 결정적 1.5초 history 지연 조건을 포함한 Playwright 1개 시나리오 통과 (`6.9s`)
+  - 전체 orchestration과 cleanup 완료 (`93.9s`)
+  - `npm run build`, 변경 파일 ESLint, PowerShell parser, Docker Compose config 통과
+  - 전체 lint는 변경과 무관한 기존 기준선 `17 errors / 4 warnings`로 실패
+- GitHub Runner 검증:
+  - `ubuntu-latest`에서 Backend `develop`과 opt-in full-stack E2E 성공 (`1m 12s`)
+  - Node 24 기반 공식 action과 Node dependency cache를 사용하고 비차단 annotation 없이 완료
+  - Playwright report와 Backend·Frontend·Mock·container 로그 artifact 업로드 확인
+- 범위 제외: 실제 외부 API, 전체 사용자 흐름, 매 PR 자동 실행, Backend production code·schema 변경
 
 ## Recently Merged
 
@@ -72,9 +104,9 @@
 
 ## Next Candidates
 
-1. 기사 요약·SSE 정상 종료와 `502/503/504` 실패 상태별 재시도 UX 검증
-2. 핵심 사용자 흐름 브라우저 회귀 테스트와 Frontend CI 구축
-3. 기존 전체 ESLint 오류 기준선 정리 (`17 errors / 4 warnings`, #92 변경 파일 제외)
+1. 기존 전체 ESLint 오류 기준선 정리 (`17 errors / 4 warnings`, #92 변경 파일 제외)
+2. Full-stack E2E 안정화 후 핵심 PR 자동 실행 승격 여부 판단
+3. 인증 사용자 스크랩·채팅 흐름의 opt-in E2E 확장 필요성 조사
 
 ## Guardrail
 

--- a/docs/frontend-improvement/full-stack-e2e.md
+++ b/docs/frontend-improvement/full-stack-e2e.md
@@ -1,0 +1,71 @@
+# Frontend-Backend Full-stack E2E
+
+## 목적
+
+수동으로 각각 실행하던 Frontend, Backend, MySQL, Redis와 브라우저 검증을 한 명령과 GitHub Runner에서 재현한다.
+Playwright가 실제 브라우저에서 사용자 입력과 화면을 검증하며, API 응답과 Redis 저장 결과도 함께 확인한다.
+
+## 실제 경로와 Mock 경계
+
+다음 경로는 실제 애플리케이션 코드와 일회성 인프라를 통과한다.
+
+```text
+Playwright Chromium
+→ Frontend 5173
+→ Vite /api proxy
+→ Backend 8080
+→ MySQL 13306 / Redis 16379
+```
+
+- 실제: Flyway migration, 기사 fixture 저장, 상세·요약 Controller/Service/Repository, SSE 처리, 익명 Redis 대화 저장·조회
+- Mock: Gemini 응답, 브라우저 Google Translation, 이 테스트 범위 밖의 Perspectives 응답
+- 비활성: News API·RSS scheduler, OAuth, 실제 외부 API 호출
+
+Mock Gemini는 외부 비용을 제거하지만 Backend WebClient, SSE 누적 데이터, named `end` 이벤트와 Redis 저장은 실제 코드를 통과한다.
+
+## 로컬 실행
+
+Frontend와 Backend 저장소가 같은 상위 디렉터리에 있을 때 Frontend 저장소 루트에서 실행한다.
+
+```powershell
+.\scripts\run-full-stack-e2e.cmd
+```
+
+첫 실행은 Playwright Chromium을 내려받는다. 이후 설치를 생략하려면 다음 옵션을 사용한다.
+
+```powershell
+.\scripts\run-full-stack-e2e.cmd -SkipBrowserInstall
+```
+
+스크립트는 Docker Desktop이 정지돼 있으면 실행을 시도하고 daemon 준비를 기다린다. 기존 개발 DB와 충돌하지 않도록 별도 포트와 일회성 volume을 사용하며 종료 시 제거한다.
+
+## GitHub Actions 실행
+
+- Actions의 `Full Stack E2E`에서 `Run workflow`를 누르고 검증할 Backend branch, tag 또는 commit SHA를 입력한다.
+- PR에서 필요할 때만 `full-stack-e2e` label을 붙이면 opt-in으로 실행된다. 일반 PR에는 자동 실행되지 않는다.
+- Runner는 Frontend와 지정한 Backend를 checkout하고 같은 PowerShell orchestration과 Playwright 테스트를 실행한다.
+
+실패 여부와 관계없이 다음 artifact를 14일간 보관한다.
+
+- Playwright HTML report
+- 실패 screenshot·video·trace
+- Backend·Frontend·Gemini Mock·container 로그
+
+## 검증 시나리오
+
+1. Flyway가 적용된 MySQL에 기사 fixture를 저장한다.
+2. 브라우저가 상세·요약 API의 HTTP 200과 응답 본문을 확인한다.
+3. 제목과 요약이 화면에 렌더링되는지 확인한다.
+4. 실제 빈 이력 응답 전달을 1.5초 늦춰 초기화 경쟁 조건을 만든다.
+5. 사용자가 질문을 입력하고 전송한다.
+6. Mock Gemini 응답이 실제 Backend SSE를 거쳐 화면에 표시되는지 확인한다.
+7. named `end` 뒤 전송 버튼이 재활성화되고 질문이 한 번만 남는지 확인한다.
+8. 동일 익명 세션의 Redis 이력 API에서 질문·답변이 저장됐는지 확인한다.
+
+## 연동 중 발견한 회귀
+
+이전 이력 조회가 끝나기 전에 질문을 보내면 늦은 초기화 응답이 진행 중 질문과 SSE 답변을 덮어쓸 수 있었다. `Chatbot`은 사용자 대화가 시작된 뒤 도착한 초기화 결과로 현재 메시지를 교체하지 않도록 변경했다. E2E는 실제 Backend 이력 응답을 의도적으로 늦춰 이 조건을 반복 검증한다.
+
+Reviewer 검토에서 메시지 내용만으로 대화 시작 여부를 판별하면 기사 A에서 B로 이동했을 때 A의 메시지가 B의 history 반영을 막을 수 있다는 회귀가 확인되었다. 이를 초기화 시점의 conversation revision과 실제 질문 시작 시점의 revision 비교로 변경했다. 기사·언어·인증 identity가 바뀌면 기존 메시지를 비우고 새 history를 반영하되, 해당 초기화가 진행되는 동안 사용자가 질문했다면 늦은 history만 폐기한다. E2E는 새로고침 없이 두 번째 기사로 이동해 첫 기사 질문이 남지 않는 조건도 검증한다.
+
+Compose project 이름은 실행 프로세스 ID를 포함해 실행별로 분리한다. 또한 해당 실행이 `docker compose up`을 시작한 경우에만 같은 project의 log 수집과 `down -v`를 수행한다. 따라서 이미 사용 중인 port를 발견해 두 번째 실행이 시작 전에 실패하더라도 먼저 실행 중인 E2E의 container와 volume을 제거하지 않는다.

--- a/scripts/run-full-stack-e2e.cmd
+++ b/scripts/run-full-stack-e2e.cmd
@@ -1,0 +1,2 @@
+@echo off
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%~dp0run-full-stack-e2e.ps1" %*

--- a/scripts/run-full-stack-e2e.ps1
+++ b/scripts/run-full-stack-e2e.ps1
@@ -1,0 +1,196 @@
+param(
+    [string]$BackendPath,
+    [switch]$SkipBrowserInstall
+)
+
+# Windows PowerShell 5.1 converts native stderr warnings into ErrorRecord objects.
+# Native tools are checked with LASTEXITCODE below; PowerShell-level failures use explicit throw.
+$ErrorActionPreference = "Continue"
+$onWindows = $env:OS -eq "Windows_NT"
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$frontendPath = Join-Path $repoRoot "FrontEnd"
+$composeFile = Join-Path $frontendPath "e2e/docker-compose.e2e.yml"
+$artifactPath = Join-Path $frontendPath "e2e-artifacts"
+$projectName = "globaltimes-fe-e2e-$PID"
+
+if (-not $BackendPath) {
+    $BackendPath = Join-Path (Split-Path $repoRoot -Parent) "GlobalTimes_BeSide"
+}
+$BackendPath = (Resolve-Path $BackendPath).Path
+
+New-Item -ItemType Directory -Force -Path $artifactPath | Out-Null
+$backendLog = Join-Path $artifactPath "backend.log"
+$backendErrorLog = Join-Path $artifactPath "backend-error.log"
+$frontendLog = Join-Path $artifactPath "frontend.log"
+$frontendErrorLog = Join-Path $artifactPath "frontend-error.log"
+$mockLog = Join-Path $artifactPath "gemini-mock.log"
+$mockErrorLog = Join-Path $artifactPath "gemini-mock-error.log"
+
+$backendProcess = $null
+$frontendProcess = $null
+$mockProcess = $null
+$composeStarted = $false
+
+function Wait-Http([string]$Url, [int]$TimeoutSeconds = 120) {
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $response = Invoke-WebRequest -UseBasicParsing -Uri $Url -TimeoutSec 3
+            if ([int]$response.StatusCode -lt 500) { return }
+        } catch {
+            Start-Sleep -Seconds 2
+        }
+    }
+    throw "Timed out waiting for $Url"
+}
+
+function Test-PortOpen([int]$Port) {
+    $client = [System.Net.Sockets.TcpClient]::new()
+    try {
+        $task = $client.ConnectAsync("127.0.0.1", $Port)
+        return $task.Wait(300) -and $client.Connected
+    } catch {
+        return $false
+    } finally {
+        $client.Dispose()
+    }
+}
+
+function Test-DockerReady([string]$Context = "") {
+    $dockerCommand = (Get-Command docker -ErrorAction SilentlyContinue).Source
+    if (-not $dockerCommand) { return $false }
+
+    $arguments = @()
+    if ($Context) { $arguments += @("--context", $Context) }
+    $arguments += @("info", "--format", "{{.ServerVersion}}")
+
+    $probeOut = Join-Path $artifactPath "docker-probe.out.log"
+    $probeError = Join-Path $artifactPath "docker-probe.error.log"
+    $probe = Start-Process -FilePath $dockerCommand `
+        -ArgumentList $arguments `
+        -RedirectStandardOutput $probeOut `
+        -RedirectStandardError $probeError `
+        -PassThru
+    if (-not $probe.WaitForExit(5000)) {
+        $probe.Kill()
+        return $false
+    }
+    $probe.WaitForExit()
+    $version = Get-Content $probeOut -Raw -ErrorAction SilentlyContinue
+    return -not [string]::IsNullOrWhiteSpace($version)
+}
+
+function Stop-Tree($Process) {
+    if (-not $Process -or $Process.HasExited) { return }
+    if ($onWindows) {
+        & taskkill.exe /PID $Process.Id /T /F 2>$null | Out-Null
+    } else {
+        & pkill -TERM -P $Process.Id 2>$null
+        Stop-Process -Id $Process.Id -Force -ErrorAction SilentlyContinue
+    }
+}
+
+try {
+    foreach ($port in 8080, 5173, 19099, 13306, 16379) {
+        if (Test-PortOpen $port) {
+            throw "Port $port is already in use. Stop the existing process before running E2E."
+        }
+    }
+
+    $dockerContext = if ($onWindows) { "desktop-linux" } else { "" }
+    if (-not (Test-DockerReady $dockerContext) -and $onWindows) {
+        $dockerDesktop = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
+        if (-not (Test-Path $dockerDesktop)) { throw "Docker Desktop is not installed." }
+        Start-Process -FilePath $dockerDesktop -WindowStyle Hidden | Out-Null
+        for ($i = 0; $i -lt 60; $i++) {
+            if (Test-DockerReady "desktop-linux") {
+                & docker context use desktop-linux | Out-Null
+                break
+            }
+            Start-Sleep -Seconds 3
+        }
+    }
+    if (-not (Test-DockerReady $dockerContext)) { throw "Docker engine is not ready." }
+
+    $composeStarted = $true
+    & docker compose -p $projectName -f $composeFile up -d
+    if ($LASTEXITCODE -ne 0) { throw "Failed to start E2E containers." }
+
+    for ($i = 0; $i -lt 60; $i++) {
+        & docker compose -p $projectName -f $composeFile exec -T mysql mysqladmin ping -h 127.0.0.1 -uroot -pe2epw *> $null
+        $mysqlReady = $LASTEXITCODE -eq 0
+        & docker compose -p $projectName -f $composeFile exec -T redis redis-cli ping *> $null
+        $redisReady = $LASTEXITCODE -eq 0
+        if ($mysqlReady -and $redisReady) { break }
+        Start-Sleep -Seconds 2
+    }
+    if (-not ($mysqlReady -and $redisReady)) { throw "E2E containers are not healthy." }
+
+    $nodeCommand = if ($onWindows) { "node.exe" } else { "node" }
+    $mockProcess = Start-Process -FilePath $nodeCommand `
+        -ArgumentList (Join-Path $frontendPath "e2e/support/gemini-mock.cjs") `
+        -WorkingDirectory $frontendPath `
+        -RedirectStandardOutput $mockLog `
+        -RedirectStandardError $mockErrorLog `
+        -PassThru
+    Wait-Http "http://127.0.0.1:19099" 30
+
+    $env:SPRING_DATASOURCE_URL = "jdbc:mysql://127.0.0.1:13306/globaltimes?useSSL=false&useUnicode=true&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true"
+    $env:SPRING_DATASOURCE_USERNAME = "root"
+    $env:SPRING_DATASOURCE_PASSWORD = "e2epw"
+    $env:SPRING_DATA_REDIS_HOST = "127.0.0.1"
+    $env:SPRING_DATA_REDIS_PORT = "16379"
+    $env:GEMINI_API_KEY = "e2e-key"
+    $env:GEMINI_BASE_URL = "http://127.0.0.1:19099"
+    $env:GOOGLE_API_KEY = "e2e-key"
+    $env:NEWS_API_KEY = "e2e-key"
+    $env:GOOGLE_OAUTH_CLIENT_ID = "e2e-client"
+    $env:GOOGLE_OAUTH_CLIENT_SECRET = "e2e-secret"
+    $env:JWT_SECRET = "e2e_jwt_secret_key_must_be_at_least_32_characters"
+    $env:NEWS_FETCH_ENABLED = "false"
+    $env:AI_SUMMARY_SAVE_ENABLED = "false"
+
+    $gradleCommand = if ($onWindows) { Join-Path $BackendPath "gradlew.bat" } else { Join-Path $BackendPath "gradlew" }
+    $backendProcess = Start-Process -FilePath $gradleCommand `
+        -ArgumentList "bootRun" `
+        -WorkingDirectory $BackendPath `
+        -RedirectStandardOutput $backendLog `
+        -RedirectStandardError $backendErrorLog `
+        -PassThru
+    Wait-Http "http://127.0.0.1:8080/api/articles/latest?page=0&size=1" 180
+
+    $fixture = Get-Content (Join-Path $frontendPath "e2e/fixtures/full-stack-smoke.sql") -Raw -Encoding utf8
+    $fixture | & docker compose -p $projectName -f $composeFile exec -T mysql mysql --default-character-set=utf8mb4 -uroot -pe2epw globaltimes
+    if ($LASTEXITCODE -ne 0) { throw "Failed to load E2E fixture." }
+
+    $npmCommand = if ($onWindows) { "npm.cmd" } else { "npm" }
+    $frontendProcess = Start-Process -FilePath $npmCommand `
+        -ArgumentList "run", "dev", "--", "--host", "127.0.0.1", "--port", "5173" `
+        -WorkingDirectory $frontendPath `
+        -RedirectStandardOutput $frontendLog `
+        -RedirectStandardError $frontendErrorLog `
+        -PassThru
+    Wait-Http "http://127.0.0.1:5173" 90
+
+    Push-Location $frontendPath
+    try {
+        $npxCommand = if ($onWindows) { "npx.cmd" } else { "npx" }
+        if (-not $SkipBrowserInstall) {
+            & $npxCommand playwright install chromium
+            if ($LASTEXITCODE -ne 0) { throw "Failed to install Playwright Chromium." }
+        }
+        $env:E2E_BASE_URL = "http://127.0.0.1:5173"
+        & $npxCommand playwright test
+        if ($LASTEXITCODE -ne 0) { throw "Playwright E2E failed." }
+    } finally {
+        Pop-Location
+    }
+} finally {
+    Stop-Tree $frontendProcess
+    Stop-Tree $backendProcess
+    Stop-Tree $mockProcess
+    if ($composeStarted) {
+        & docker compose -p $projectName -f $composeFile logs --no-color *> (Join-Path $artifactPath "containers.log")
+        & docker compose -p $projectName -f $composeFile down -v --remove-orphans
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용

### 실제 Frontend-Backend E2E 자동화
- Playwright Chromium → Frontend `5173` → Vite proxy → Backend `8080` → MySQL `13306`/Redis `16379` 경로를 한 시나리오로 검증합니다.
- 전용 Docker Compose와 일회성 volume으로 기존 로컬 DB를 건드리지 않고 Flyway migration과 기사 fixture를 재현합니다.
- Gemini만 로컬 Mock으로 대체하고 실제 Backend SSE `data → end`, 익명 Redis 저장·조회 경로를 유지합니다.
- Windows에서는 `scripts/run-full-stack-e2e.cmd` 한 명령으로 Docker 준비부터 전체 서버 기동·Playwright·cleanup을 수행합니다.

### GitHub Runner
- `Full Stack E2E` workflow의 `Run workflow`에서 Backend ref를 지정해 수동 실행할 수 있습니다.
- PR에는 `full-stack-e2e` label을 붙인 경우에만 opt-in으로 실행합니다.
- 실패 여부와 관계없이 Playwright report·trace·screenshot·video와 서버·컨테이너 로그를 artifact로 보관합니다.

### 연동 중 발견한 Frontend 문제와 해결
- 이전 채팅 이력 조회가 끝나기 전에 사용자가 질문하면 늦은 초기화 응답이 진행 중 질문과 SSE 답변을 덮어쓰는 race를 실제 브라우저 E2E에서 발견했습니다.
- 초기화 시점과 실제 질문 시작 시점의 conversation revision을 비교해, 질문 이후 늦게 도착한 동일 초기화 결과만 폐기합니다.
- 기사·언어·인증 identity 변경 시에는 기존 메시지를 초기화하고 새 history를 반영합니다.

### Reviewer Blocking 반영
- 새로고침 없이 기사 A에서 B로 이동할 때 A의 대화가 B에 남지 않는 Playwright 회귀 시나리오를 추가했습니다.
- Compose project 이름을 실행 PID별로 분리하고, 해당 실행이 `up`을 시작한 경우에만 같은 project를 `down -v`하도록 ownership guard를 적용했습니다.
- 두 번째 실행이 port preflight에서 실패해도 먼저 실행 중인 E2E의 container와 volume을 제거하지 않습니다.

## ✅ 체크리스트
- [x] 로컬 Playwright 실제 Backend 시나리오 성공 (`test-results/.last-run.json: passed`)
- [x] 상세·요약 HTTP 200과 응답 본문·화면 렌더링 확인
- [x] SSE 응답·named `end`·입력 재활성화·질문 중복 없음 확인
- [x] 동일 익명 세션 Redis 질의·응답 저장 확인
- [x] 기사 A→B client-side 이동 시 이전 질문 제거 확인
- [x] `npm.cmd run build` 성공 (기존 bundle size warning만 유지)
- [x] 변경 파일 ESLint `--max-warnings 0` 성공
- [x] PowerShell parser와 `git diff --check` 성공
- [x] Blocking 반영 후 GitHub Ubuntu Runner 전체 E2E 성공 (`1m 18s`, run `31490194111`)
- [x] 실행·Mock 경계·회귀 조건을 문서화

전체 `npm run lint`는 이번 변경과 무관한 기존 기준선 `17 errors / 4 warnings`로 실패합니다. 로컬 전체 orchestration은 Playwright 성공 후 Docker Desktop daemon 응답 지연으로 외부 명령 제한에 걸렸으며, 동일 스크립트의 기동·테스트·cleanup 전체 경로는 Ubuntu Runner에서 성공했습니다.

## 범위 제외
- 실제 Gemini·Google Translation·News API·RSS·OAuth 호출
- Perspectives 품질 검증과 전체 사용자 흐름
- 모든 PR의 자동 E2E 실행
- Backend production code·schema 변경

## 🔗 관련 이슈
Closes #96

Backend: SKU-GlobalTimes/GlobalTimes_BeSide#245, SKU-GlobalTimes/GlobalTimes_BeSide#246

## 💬 리뷰 요청사항
- conversation revision이 늦은 동일 초기화 응답만 막고 기사·언어·인증 identity 변경 시 새 history를 정상 반영하는지 확인해주세요.
- 실행별 Compose project와 ownership guard가 다른 실행의 container·volume을 정리하지 않는지 확인해주세요.
- workflow가 일반 PR마다 실행되지 않고 manual/label opt-in으로만 실행되는지 확인해주세요.
