### PR TITLE
💻 [TEST/#98] 인증 사용자 스크랩·채팅 실제 연동 E2E 확장

### DIFF
--- a/FrontEnd/e2e/authenticated-user.spec.js
+++ b/FrontEnd/e2e/authenticated-user.spec.js
@@ -1,0 +1,130 @@
+import { expect, test } from "@playwright/test";
+import { createE2eJwt, E2E_USER } from "./support/auth-token.js";
+
+const ARTICLE_ID = 990_096;
+const ARTICLE_TITLE = "Full-stack E2E verification article";
+const ANSWER = "Backend SSE integration verified";
+
+test("인증 사용자의 스크랩과 채팅을 실제 Backend와 MySQL에 저장한다", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+  const token = createE2eJwt();
+  const authorization = { Authorization: `Bearer ${token}` };
+  const question = `Authenticated E2E question ${Date.now()}`;
+
+  await page.addInitScript((jwt) => {
+    window.localStorage.setItem("token", jwt);
+  }, token);
+
+  await page.route("https://translation.googleapis.com/**", async (route) => {
+    const body = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: { translations: [{ translatedText: body.q }] },
+      }),
+    });
+  });
+
+  await page.route("**/api/news/*/perspectives", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ isSuccess: true, message: "success", data: {} }),
+    });
+  });
+
+  const initialStatus = await page.request.get(
+    `/api/articles/${ARTICLE_ID}/scrap/status`,
+    { headers: authorization },
+  );
+  expect(initialStatus.status()).toBe(200);
+  if ((await initialStatus.json()).data.scrapped) {
+    const resetResponse = await page.request.post(
+      `/api/articles/${ARTICLE_ID}/scrap`,
+      { headers: authorization },
+    );
+    expect((await resetResponse.json()).data.scrapped).toBe(false);
+  }
+
+  const userResponsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/user/me"),
+  );
+  const scrapStatusPromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/articles/${ARTICLE_ID}/scrap/status`),
+  );
+  await page.goto(`/detail/${ARTICLE_ID}`);
+
+  const [userResponse, scrapStatusResponse] = await Promise.all([
+    userResponsePromise,
+    scrapStatusPromise,
+  ]);
+  expect(userResponse.status()).toBe(200);
+  expect((await userResponse.json()).data.nickname).toBe(E2E_USER.nickname);
+  expect(scrapStatusResponse.status()).toBe(200);
+  await expect(
+    page.getByText(E2E_USER.nickname, { exact: false }).first(),
+  ).toBeVisible();
+
+  await page.getByRole("button", { name: "스크랩", exact: true }).click();
+  const toggleResponsePromise = page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      response.url().includes(`/api/articles/${ARTICLE_ID}/scrap`),
+  );
+  await page
+    .getByRole("button", { name: "스크랩", exact: true })
+    .first()
+    .click();
+  const toggleResponse = await toggleResponsePromise;
+  expect(toggleResponse.status()).toBe(200);
+  expect((await toggleResponse.json()).data.scrapped).toBe(true);
+  await expect(
+    page.getByRole("button", { name: "스크랩됨", exact: true }),
+  ).toBeVisible();
+
+  const scrapListResponsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/user/scraps"),
+  );
+  await page.getByText("마이스크랩", { exact: true }).first().click();
+  expect((await scrapListResponsePromise).status()).toBe(200);
+  await expect(page.getByText(ARTICLE_TITLE, { exact: true })).toBeVisible();
+
+  await page.goto(`/detail/${ARTICLE_ID}`);
+  const input = page.getByPlaceholder("질문을 입력하세요...");
+  const sendButton = page.getByRole("button", { name: "질문 보내기" });
+  await input.fill(question);
+
+  const askResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/ai/${ARTICLE_ID}/ask?`),
+  );
+  await sendButton.click();
+  const askResponse = await askResponsePromise;
+  expect(askResponse.status()).toBe(200);
+  expect(askResponse.headers()["content-type"]).toContain("text/event-stream");
+  await expect(page.getByText(ANSWER, { exact: true })).toBeVisible();
+  await expect(sendButton).toBeEnabled();
+
+  await expect
+    .poll(async () => {
+      const response = await page.request.get(
+        `/api/articles/${ARTICLE_ID}/chat-history`,
+        { headers: authorization },
+      );
+      if (!response.ok()) return false;
+      const history = (await response.json()).data;
+      return history.some(
+        (chat) => chat.question === question && chat.answer === ANSWER,
+      );
+    })
+    .toBe(true);
+
+  const chatListResponsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/user/chat-history"),
+  );
+  await page.getByRole("button", { name: "채팅 히스토리" }).click();
+  expect((await chatListResponsePromise).status()).toBe(200);
+  await expect(page.getByText(`Q: ${question}`, { exact: true })).toBeVisible();
+});

--- a/FrontEnd/e2e/fixtures/full-stack-smoke.sql
+++ b/FrontEnd/e2e/fixtures/full-stack-smoke.sql
@@ -2,6 +2,19 @@ INSERT INTO source (source_id, source_api_id, source_name)
 VALUES (990096, 'e2e-source', 'E2E Press')
 ON DUPLICATE KEY UPDATE source_name = VALUES(source_name);
 
+INSERT INTO users (user_id, created_at, email, nickname, provider, provider_id)
+VALUES (
+  990098,
+  '2026-08-12 00:00:00',
+  'authenticated-e2e@example.com',
+  'Authenticated E2E User',
+  'e2e',
+  'authenticated-e2e-user'
+)
+ON DUPLICATE KEY UPDATE
+  email = VALUES(email),
+  nickname = VALUES(nickname);
+
 INSERT INTO article (
   article_id, author, category, content, country, crawled_content,
   description, published_at, summary, title, url, url_to_image,

--- a/FrontEnd/e2e/support/auth-token.js
+++ b/FrontEnd/e2e/support/auth-token.js
@@ -1,0 +1,32 @@
+import { createHmac } from "node:crypto";
+
+export const E2E_USER = {
+  id: 990_098,
+  email: "authenticated-e2e@example.com",
+  nickname: "Authenticated E2E User",
+};
+
+const encode = (value) =>
+  Buffer.from(JSON.stringify(value)).toString("base64url");
+
+export function createE2eJwt() {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("JWT_SECRET is required for the authenticated E2E flow.");
+  }
+
+  const now = Math.floor(Date.now() / 1_000);
+  const header = encode({ alg: "HS256", typ: "JWT" });
+  const payload = encode({
+    sub: String(E2E_USER.id),
+    email: E2E_USER.email,
+    iat: now,
+    exp: now + 10 * 60,
+  });
+  const unsignedToken = `${header}.${payload}`;
+  const signature = createHmac("sha256", secret)
+    .update(unsignedToken)
+    .digest("base64url");
+
+  return `${unsignedToken}.${signature}`;
+}

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -13,6 +13,29 @@
 
 ## In Progress
 
+### #98 인증 사용자 스크랩·채팅 실제 연동 E2E
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/issues/98
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/pull/99
+- Branch: `test/98-authenticated-user-e2e`
+- 목적: OAuth 성공 이후 JWT 인증 사용자의 스크랩·AI 채팅 핵심 흐름을 실제 Frontend → Backend → MySQL 경로로 자동 검증합니다.
+- 범위:
+  - E2E user fixture와 실행 시점 JWT 생성
+  - `/api/user/me`와 Backend JWT filter 실제 통과
+  - 기사 스크랩 저장·상태 조회·마이 스크랩 화면 반영
+  - 로그인 SSE 질의·DB 채팅 history 저장·히스토리 팝업 노출
+- Mock 경계: 실제 Google OAuth와 Gemini·화면 번역·Perspectives 품질 검증은 제외합니다.
+- Overengineering 판단: 기존 #96 Playwright orchestration을 확장하며 테스트 전용 Backend endpoint나 신규 인증 도구를 추가하지 않습니다.
+- 로컬 검증 중 Docker readiness probe가 Windows에서 반복적으로 console 창을 생성하는 문제를 발견해 hidden process, timeout wait, dispose 경계를 보강했습니다.
+- 인증 GET은 성공하지만 스크랩 POST가 403인 원인을 E2E `127.0.0.1` Origin과 Backend 허용 `localhost` Origin 불일치로 확인해 브라우저 base URL을 `localhost:5173`으로 정렬했습니다.
+- 로컬 검증:
+  - 인증·익명 Playwright 2개 시나리오 통과 (`11.1s`)
+  - 전체 Backend·MySQL·Redis orchestration과 cleanup 완료 (`71.3s`)
+  - JWT `/api/user/me`, 스크랩 저장·목록 재조회, 로그인 SSE·DB chat history·히스토리 팝업 노출 확인
+  - Docker readiness console 창 및 CLI process 누적 없이 완료
+  - Production build, 변경 E2E 파일 ESLint, PowerShell parser와 `git diff --check` 통과
+  - GitHub `ubuntu-latest` Full Stack E2E 성공 (`1m 34s`, run `31517789173`)
+
 ## Recently Merged
 
 ### #96/#97 Frontend-Backend 실제 연동 Playwright 자동화

--- a/docs/frontend-improvement/full-stack-e2e.md
+++ b/docs/frontend-improvement/full-stack-e2e.md
@@ -69,3 +69,13 @@ Frontend와 Backend 저장소가 같은 상위 디렉터리에 있을 때 Fronte
 Reviewer 검토에서 메시지 내용만으로 대화 시작 여부를 판별하면 기사 A에서 B로 이동했을 때 A의 메시지가 B의 history 반영을 막을 수 있다는 회귀가 확인되었다. 이를 초기화 시점의 conversation revision과 실제 질문 시작 시점의 revision 비교로 변경했다. 기사·언어·인증 identity가 바뀌면 기존 메시지를 비우고 새 history를 반영하되, 해당 초기화가 진행되는 동안 사용자가 질문했다면 늦은 history만 폐기한다. E2E는 새로고침 없이 두 번째 기사로 이동해 첫 기사 질문이 남지 않는 조건도 검증한다.
 
 Compose project 이름은 실행 프로세스 ID를 포함해 실행별로 분리한다. 또한 해당 실행이 `docker compose up`을 시작한 경우에만 같은 project의 log 수집과 `down -v`를 수행한다. 따라서 이미 사용 중인 port를 발견해 두 번째 실행이 시작 전에 실패하더라도 먼저 실행 중인 E2E의 container와 volume을 제거하지 않는다.
+
+## 인증 사용자 시나리오
+
+실제 Google OAuth 로그인은 외부 계정과 redirect 정책에 의존하므로 E2E 범위에서 제외한다. 대신 fixture 사용자와 실행 시점의 E2E `JWT_SECRET`으로 10분 유효 JWT를 생성한다. 저장소에는 완성된 token을 기록하지 않는다.
+
+브라우저가 localStorage의 token을 읽은 뒤 실제 Backend `JwtAuthenticationFilter`와 Security matcher를 통과한다. `/api/user/me` 인증, 기사 스크랩 저장과 `/api/user/scraps` 재조회, 로그인 AI SSE 질의, MySQL `chat_history` 조회와 채팅 히스토리 팝업 노출을 순서대로 검증한다. Gemini와 화면 번역 Mock 경계는 익명 시나리오와 동일하다.
+
+Windows에서는 E2E artifact 아래의 임시 Docker config와 Docker Desktop Linux named pipe를 사용해 사용자 전역 Docker config 권한과 context 전환에 의존하지 않는다. readiness probe는 숨김 process로 실행하며 각 probe는 5초 timeout 뒤 종료 완료를 기다리고 process handle을 dispose한다. 전체 준비 대기도 2분으로 제한해 Docker daemon 응답이 늦어도 `docker.exe` console 창과 process가 누적되거나 대기가 과도하게 길어지지 않는다.
+
+브라우저 base URL은 Backend CORS에 등록된 `http://localhost:5173`을 사용한다. 같은 로컬 서버라도 `127.0.0.1`은 다른 Origin이므로 GET에는 드러나지 않던 CORS 불일치가 Origin header를 포함한 스크랩 POST에서 403으로 나타날 수 있다.

--- a/scripts/run-full-stack-e2e.ps1
+++ b/scripts/run-full-stack-e2e.ps1
@@ -19,6 +19,13 @@ if (-not $BackendPath) {
 $BackendPath = (Resolve-Path $BackendPath).Path
 
 New-Item -ItemType Directory -Force -Path $artifactPath | Out-Null
+$dockerContext = ""
+if ($onWindows) {
+    $dockerConfigPath = Join-Path $artifactPath "docker-config"
+    New-Item -ItemType Directory -Force -Path $dockerConfigPath | Out-Null
+    $env:DOCKER_CONFIG = $dockerConfigPath
+    $env:DOCKER_HOST = "npipe:////./pipe/dockerDesktopLinuxEngine"
+}
 $backendLog = Join-Path $artifactPath "backend.log"
 $backendErrorLog = Join-Path $artifactPath "backend-error.log"
 $frontendLog = Join-Path $artifactPath "frontend.log"
@@ -66,18 +73,29 @@ function Test-DockerReady([string]$Context = "") {
 
     $probeOut = Join-Path $artifactPath "docker-probe.out.log"
     $probeError = Join-Path $artifactPath "docker-probe.error.log"
-    $probe = Start-Process -FilePath $dockerCommand `
-        -ArgumentList $arguments `
-        -RedirectStandardOutput $probeOut `
-        -RedirectStandardError $probeError `
-        -PassThru
-    if (-not $probe.WaitForExit(5000)) {
-        $probe.Kill()
-        return $false
+    $startProcessArgs = @{
+        FilePath = $dockerCommand
+        ArgumentList = $arguments
+        RedirectStandardOutput = $probeOut
+        RedirectStandardError = $probeError
+        PassThru = $true
     }
-    $probe.WaitForExit()
-    $version = Get-Content $probeOut -Raw -ErrorAction SilentlyContinue
-    return -not [string]::IsNullOrWhiteSpace($version)
+    if ($onWindows) {
+        $startProcessArgs.WindowStyle = "Hidden"
+    }
+
+    $probe = Start-Process @startProcessArgs
+    try {
+        if (-not $probe.WaitForExit(5000)) {
+            $probe.Kill()
+            $probe.WaitForExit()
+            return $false
+        }
+        $version = Get-Content $probeOut -Raw -ErrorAction SilentlyContinue
+        return -not [string]::IsNullOrWhiteSpace($version)
+    } finally {
+        $probe.Dispose()
+    }
 }
 
 function Stop-Tree($Process) {
@@ -97,14 +115,13 @@ try {
         }
     }
 
-    $dockerContext = if ($onWindows) { "desktop-linux" } else { "" }
     if (-not (Test-DockerReady $dockerContext) -and $onWindows) {
         $dockerDesktop = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
         if (-not (Test-Path $dockerDesktop)) { throw "Docker Desktop is not installed." }
         Start-Process -FilePath $dockerDesktop -WindowStyle Hidden | Out-Null
-        for ($i = 0; $i -lt 60; $i++) {
-            if (Test-DockerReady "desktop-linux") {
-                & docker context use desktop-linux | Out-Null
+        $dockerDeadline = (Get-Date).AddSeconds(120)
+        while ((Get-Date) -lt $dockerDeadline) {
+            if (Test-DockerReady $dockerContext) {
                 break
             }
             Start-Sleep -Seconds 3
@@ -170,7 +187,7 @@ try {
         -RedirectStandardOutput $frontendLog `
         -RedirectStandardError $frontendErrorLog `
         -PassThru
-    Wait-Http "http://127.0.0.1:5173" 90
+    Wait-Http "http://localhost:5173" 90
 
     Push-Location $frontendPath
     try {
@@ -179,7 +196,7 @@ try {
             & $npxCommand playwright install chromium
             if ($LASTEXITCODE -ne 0) { throw "Failed to install Playwright Chromium." }
         }
-        $env:E2E_BASE_URL = "http://127.0.0.1:5173"
+        $env:E2E_BASE_URL = "http://localhost:5173"
         & $npxCommand playwright test
         if ($LASTEXITCODE -ne 0) { throw "Playwright E2E failed." }
     } finally {


### PR DESCRIPTION
## 📌 작업 내용

### 인증 사용자 실제 연동 E2E
- E2E user fixture와 실행 시점 `JWT_SECRET`으로 10분 유효 JWT를 생성합니다. 완성된 token은 저장소에 남기지 않습니다.
- 브라우저 localStorage의 token으로 실제 Backend `JwtAuthenticationFilter`와 Security matcher를 통과합니다.
- `/api/user/me`, 기사 스크랩 저장·상태 조회·마이 스크랩 재조회, 로그인 AI SSE, MySQL chat history와 히스토리 팝업을 한 사용자 흐름으로 검증합니다.
- 실제 Google OAuth·Gemini·번역·Perspectives 품질은 기존 Mock 경계를 유지합니다.

### 연동 검증 중 발견한 문제와 해결
- Docker daemon 응답 지연 시 readiness probe가 Windows console 창을 반복 생성하던 문제를 hidden process, timeout wait, dispose와 전체 2분 상한으로 보강했습니다.
- 실행 계정의 사용자 Docker config 권한에 의존하지 않도록 E2E 임시 config와 Docker Desktop Linux named pipe를 사용합니다.
- E2E의 `127.0.0.1:5173` Origin과 Backend CORS의 `localhost:5173` 허용값 불일치로 스크랩 POST가 403이던 문제를 확인하고 browser base URL을 `localhost`로 정렬했습니다.

## ✅ 체크리스트
- [x] 로컬 확인 완료
- [x] BE 연동 확인 완료
- [x] 인증·익명 Playwright 2개 시나리오 통과 (`11.1s`)
- [x] 전체 Backend·MySQL·Redis orchestration과 cleanup 완료 (`71.3s`)
- [x] JWT 인증, 스크랩 MySQL 저장·재조회, 로그인 SSE·DB chat history 확인
- [x] Production build 성공 (기존 bundle size warning만 유지)
- [x] 변경 E2E 파일 ESLint `--max-warnings 0` 성공
- [x] PowerShell parser와 `git diff --check` 성공
- [x] visible Docker CLI 창과 E2E listening port 잔존 없음
- [x] 최종 HEAD GitHub Ubuntu Runner Full Stack E2E 성공 (`1m 25s`, run `31517998965`)

## 🔗 관련 이슈
Closes #98

## 💬 리뷰 요청사항
- E2E JWT 생성이 Backend `JwtUtil` claim·signature 형식과 일치하고 실제 token을 노출하지 않는지 확인해주세요.
- 스크랩과 로그인 채팅 검증이 실제 Backend·MySQL 경로를 통과하며 외부 Mock 경계가 과도하지 않은지 확인해주세요.
- Windows Docker config·named pipe·hidden probe·cleanup 변경이 Linux Runner 경로를 회귀시키지 않는지 확인해주세요.
- `localhost` Origin 정렬이 Backend CORS 계약과 일치하는지 확인해주세요.
