### PR TITLE
🧪 [TEST/#102] 다국어 검색·Perspectives 실제 연동 E2E 확장

### DIFF
--- a/FrontEnd/e2e/fixtures/full-stack-smoke.sql
+++ b/FrontEnd/e2e/fixtures/full-stack-smoke.sql
@@ -2,6 +2,13 @@ INSERT INTO source (source_id, source_api_id, source_name)
 VALUES (990096, 'e2e-source', 'E2E Press')
 ON DUPLICATE KEY UPDATE source_name = VALUES(source_name);
 
+INSERT INTO source (source_id, source_api_id, source_name)
+VALUES
+  (990102, 'e2e-perspectives-kr', 'Lunaris Korea'),
+  (990103, 'e2e-perspectives-us', 'Lunaris US'),
+  (990104, 'e2e-perspectives-jp', 'Lunaris Japan')
+ON DUPLICATE KEY UPDATE source_name = VALUES(source_name);
+
 INSERT INTO users (user_id, created_at, email, nickname, provider, provider_id)
 VALUES (
   990098,
@@ -40,6 +47,70 @@ ON DUPLICATE KEY UPDATE
   crawled_content = VALUES(crawled_content),
   summary = VALUES(summary),
   title = VALUES(title);
+
+INSERT INTO article (
+  article_id, author, category, content, country, crawled_content,
+  description, published_at, summary, title, url, url_to_image,
+  view_count, source_id, language
+) VALUES
+  (
+    990102,
+    'E2E Korea Author',
+    'politics',
+    '루나리스 정상회담 공동성명 기사 본문입니다.',
+    'KR',
+    '루나리스 정상회담에서 공동성명을 발표한 배경과 주요 합의를 설명합니다.',
+    '루나리스 정상회담 공동성명과 국가별 반응을 다룹니다.',
+    '2026-08-11 10:00:00',
+    '루나리스 정상회담 공동성명 요약입니다.',
+    '루나리스 정상회담 공동성명 발표',
+    'https://example.com/e2e/lunaris-kr',
+    '',
+    0,
+    990102,
+    'ko'
+  ),
+  (
+    990103,
+    'E2E US Author',
+    'politics',
+    'US coverage of the Lunaris summit joint statement.',
+    'US',
+    'US officials respond to the Lunaris summit joint statement and its agreements.',
+    'Lunaris summit joint statement draws a response from US officials.',
+    '2026-08-11 09:00:00',
+    'US response to the Lunaris summit joint statement.',
+    'Lunaris summit joint statement draws US response',
+    'https://example.com/e2e/lunaris-us',
+    '',
+    0,
+    990103,
+    'en'
+  ),
+  (
+    990104,
+    'E2E Japan Author',
+    'politics',
+    'Japan coverage of the Lunaris summit joint statement.',
+    'JP',
+    'Japan reviews the Lunaris summit joint statement and regional implications.',
+    'Japan reviews the Lunaris summit joint statement and regional implications.',
+    '2026-08-11 08:00:00',
+    'Japan response to the Lunaris summit joint statement.',
+    'Japan reviews Lunaris summit joint statement',
+    'https://example.com/e2e/lunaris-jp',
+    '',
+    0,
+    990104,
+    'en'
+  )
+ON DUPLICATE KEY UPDATE
+  country = VALUES(country),
+  description = VALUES(description),
+  crawled_content = VALUES(crawled_content),
+  summary = VALUES(summary),
+  title = VALUES(title),
+  language = VALUES(language);
 
 INSERT INTO article (
   article_id, author, category, content, country, crawled_content,

--- a/FrontEnd/e2e/fixtures/redis-translations.json
+++ b/FrontEnd/e2e/fixtures/redis-translations.json
@@ -1,0 +1,10 @@
+[
+  {
+    "key": "translation:루나리스 정상회담",
+    "value": "Lunaris summit"
+  },
+  {
+    "key": "translation:루나리스 정상회담 공동성명",
+    "value": "Lunaris summit joint statement"
+  }
+]

--- a/FrontEnd/e2e/search-perspectives.spec.js
+++ b/FrontEnd/e2e/search-perspectives.spec.js
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+
+const SEARCH_TEXT = "루나리스 정상회담";
+const TRANSLATED_TEXT = "Lunaris summit";
+const BASE_ARTICLE_ID = 990_102;
+const BASE_ARTICLE_TITLE = "루나리스 정상회담 공동성명 발표";
+const US_ARTICLE_ID = 990_103;
+const US_ARTICLE_TITLE = "Lunaris summit joint statement draws US response";
+const JP_ARTICLE_ID = 990_104;
+const JP_ARTICLE_TITLE = "Japan reviews Lunaris summit joint statement";
+
+test("다국어 검색과 국가별 Perspectives를 실제 Backend 경로로 검증한다", async ({ page }) => {
+  await page.route("https://translation.googleapis.com/**", async (route) => {
+    const body = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: { translations: [{ translatedText: body.q }] },
+      }),
+    });
+  });
+
+  await page.goto("/main");
+
+  const searchInput = page.getByRole("textbox").first();
+  await searchInput.fill(SEARCH_TEXT);
+
+  const searchResponsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/search?") &&
+    new URL(response.url()).searchParams.get("text") === SEARCH_TEXT,
+  );
+  await searchInput.press("Enter");
+
+  const searchResponse = await searchResponsePromise;
+  expect(searchResponse.status()).toBe(200);
+  const searchPayload = await searchResponse.json();
+  expect(searchPayload.data.originalText).toBe(SEARCH_TEXT);
+  expect(searchPayload.data.translatedText).toBe(TRANSLATED_TEXT);
+  expect(searchPayload.data.searchArticles.map(({ id }) => id)).toEqual(
+    expect.arrayContaining([BASE_ARTICLE_ID, US_ARTICLE_ID, JP_ARTICLE_ID]),
+  );
+
+  await expect(page).toHaveURL(new RegExp(`/search/${encodeURIComponent(SEARCH_TEXT)}`));
+  await expect(page.getByText(BASE_ARTICLE_TITLE, { exact: true })).toBeVisible();
+  await expect(page.getByText(US_ARTICLE_TITLE, { exact: true })).toBeVisible();
+  await expect(page.getByText(JP_ARTICLE_TITLE, { exact: true })).toBeVisible();
+
+  const perspectivesResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/news/${BASE_ARTICLE_ID}/perspectives`),
+  );
+  await page.getByText(BASE_ARTICLE_TITLE, { exact: true }).click();
+
+  const perspectivesResponse = await perspectivesResponsePromise;
+  expect(perspectivesResponse.status()).toBe(200);
+  const perspectivesPayload = await perspectivesResponse.json();
+  expect(perspectivesPayload.data.keyword).toBe("루나리스 정상회담 공동성명");
+  expect(perspectivesPayload.data.perspectives.US).toEqual([
+    expect.objectContaining({ id: US_ARTICLE_ID, title: US_ARTICLE_TITLE }),
+  ]);
+  expect(perspectivesPayload.data.perspectives.JP).toEqual([
+    expect.objectContaining({ id: JP_ARTICLE_ID, title: JP_ARTICLE_TITLE }),
+  ]);
+
+  await expect(page.getByText(/탐색 키워드:/)).toBeVisible();
+  const usPerspectiveCard = page.getByRole("button").filter({ hasText: US_ARTICLE_TITLE });
+  const jpPerspectiveCard = page.getByRole("button").filter({ hasText: JP_ARTICLE_TITLE });
+  await expect(usPerspectiveCard).toBeVisible();
+  await expect(jpPerspectiveCard).toBeVisible();
+
+  const warmResponse = await page.request.get(`/api/news/${BASE_ARTICLE_ID}/perspectives`);
+  expect(warmResponse.status()).toBe(200);
+  expect((await warmResponse.json()).data).toEqual(perspectivesPayload.data);
+
+  const relatedDetailResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/news/detail?id=${US_ARTICLE_ID}`),
+  );
+  await usPerspectiveCard.click();
+  expect((await relatedDetailResponsePromise).status()).toBe(200);
+  await expect(page).toHaveURL(`/detail/${US_ARTICLE_ID}`);
+  await expect(page.getByRole("heading", { name: US_ARTICLE_TITLE })).toBeVisible();
+});

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -13,7 +13,31 @@
 
 ## In Progress
 
-- 없음
+### #102 다국어 검색·Perspectives 실제 Backend 연동 E2E
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/issues/102
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/pull/103
+- Branch: `test/102-search-perspectives-e2e`
+- 목적: Backend Phase 1의 번역 cache·MySQL FULLTEXT·Perspectives 국가 그룹·Redis cache 계약을 실제 Frontend 화면까지 자동 검증합니다.
+- 실제 경로:
+  - 한국어 검색 입력 → Backend `/api/search` → Redis 번역 cache hit → MySQL FULLTEXT 원문·번역어 검색
+  - 한국 기준 기사 상세 → Backend `/api/news/{id}/perspectives` → 국가별 관련 기사 계산·Redis cache 저장과 warm 재조회
+  - Perspectives 미국 기사 카드 → 실제 상세 API와 client-side route 이동
+- Fixture·Mock 경계:
+  - MySQL에 동일 이슈의 한국·미국·일본 기사와 언론사 fixture를 적재합니다.
+  - Backend 번역은 Redis에 미리 넣은 고정 결과를 사용해 실제 `TranslationService` cache 경로를 통과하며 Google Translation API는 호출하지 않습니다.
+  - 브라우저 UI 번역과 Gemini upstream만 기존처럼 Mock하고 검색·FULLTEXT·Perspectives·Redis는 실제 경로를 사용합니다.
+- Overengineering 판단: 신규 Backend API나 테스트 프레임워크 없이 기존 Playwright·MySQL·Redis orchestration을 확장했습니다.
+- 연동 중 발견한 문제:
+  - Windows PowerShell native stdin으로 SQL을 전달하면 한글이 `????`로 손상되어 `docker compose cp` 후 container 내부 mysql client로 적재하도록 변경했습니다.
+  - CSS animated placeholder는 실제 input `placeholder` 속성이 아니므로 Playwright textbox role을 사용했습니다.
+  - 같은 관련 기사가 Perspectives와 최근기사에 함께 노출되어 strict locator를 button 카드로 한정했습니다.
+  - 첫 Ubuntu Runner에서 Docker probe가 순간 실패하자 Linux는 재시도 없이 종료되어, Windows·Linux 모두 최대 120초 bounded readiness retry를 사용하도록 보완했습니다.
+- 검증 결과:
+  - 익명·인증·검색/Perspectives Playwright 3개 시나리오 통과 (`13.6s`)
+  - 전체 Backend·MySQL·Redis orchestration과 cache key 확인·cleanup 완료 (`71.0s`)
+  - Vite 7 Production build 통과 (`2,338 modules`, `7.09s`)
+  - 신규 E2E ESLint, PowerShell parser와 `git diff --check` 통과
 
 ## Recently Merged
 

--- a/docs/frontend-improvement/full-stack-e2e.md
+++ b/docs/frontend-improvement/full-stack-e2e.md
@@ -18,7 +18,8 @@ Playwright Chromium
 ```
 
 - 실제: Flyway migration, 기사 fixture 저장, 상세·요약 Controller/Service/Repository, SSE 처리, 익명 Redis 대화 저장·조회
-- Mock: Gemini 응답, 브라우저 Google Translation, 이 테스트 범위 밖의 Perspectives 응답
+- Mock: Gemini 응답과 브라우저 Google Translation
+- 실제 경로: Redis에 고정 번역 fixture를 넣은 Backend 다국어 검색, MySQL FULLTEXT, Perspectives 계산·Redis cache·국가별 기사 이동
 - 비활성: News API·RSS scheduler, OAuth, 실제 외부 API 호출
 
 Mock Gemini는 외부 비용을 제거하지만 Backend WebClient, SSE 누적 데이터, named `end` 이벤트와 Redis 저장은 실제 코드를 통과한다.
@@ -76,6 +77,6 @@ Compose project 이름은 실행 프로세스 ID를 포함해 실행별로 분�
 
 브라우저가 localStorage의 token을 읽은 뒤 실제 Backend `JwtAuthenticationFilter`와 Security matcher를 통과한다. `/api/user/me` 인증, 기사 스크랩 저장과 `/api/user/scraps` 재조회, 로그인 AI SSE 질의, MySQL `chat_history` 조회와 채팅 히스토리 팝업 노출을 순서대로 검증한다. Gemini와 화면 번역 Mock 경계는 익명 시나리오와 동일하다.
 
-Windows에서는 E2E artifact 아래의 임시 Docker config와 Docker Desktop Linux named pipe를 사용해 사용자 전역 Docker config 권한과 context 전환에 의존하지 않는다. readiness probe는 숨김 process로 실행하며 각 probe는 5초 timeout 뒤 종료 완료를 기다리고 process handle을 dispose한다. 전체 준비 대기도 2분으로 제한해 Docker daemon 응답이 늦어도 `docker.exe` console 창과 process가 누적되거나 대기가 과도하게 길어지지 않는다.
+Windows에서는 E2E artifact 아래의 임시 Docker config와 Docker Desktop Linux named pipe를 사용해 사용자 전역 Docker config 권한과 context 전환에 의존하지 않는다. readiness probe는 숨김 process로 실행하며 각 probe는 5초 timeout 뒤 종료 완료를 기다리고 process handle을 dispose한다. Windows와 Linux 모두 전체 준비 대기를 2분으로 제한한 bounded retry를 사용해 Docker daemon의 일시적인 준비 지연은 흡수하되 console 창·process 누적이나 무한 대기는 방지한다.
 
 브라우저 base URL은 Backend CORS에 등록된 `http://localhost:5173`을 사용한다. 같은 로컬 서버라도 `127.0.0.1`은 다른 Origin이므로 GET에는 드러나지 않던 CORS 불일치가 Origin header를 포함한 스크랩 POST에서 403으로 나타날 수 있다.

--- a/scripts/run-full-stack-e2e.ps1
+++ b/scripts/run-full-stack-e2e.ps1
@@ -115,19 +115,23 @@ try {
         }
     }
 
-    if (-not (Test-DockerReady $dockerContext) -and $onWindows) {
-        $dockerDesktop = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
-        if (-not (Test-Path $dockerDesktop)) { throw "Docker Desktop is not installed." }
-        Start-Process -FilePath $dockerDesktop -WindowStyle Hidden | Out-Null
+    $dockerReady = Test-DockerReady $dockerContext
+    if (-not $dockerReady) {
+        if ($onWindows) {
+            $dockerDesktop = "C:\Program Files\Docker\Docker\Docker Desktop.exe"
+            if (-not (Test-Path $dockerDesktop)) { throw "Docker Desktop is not installed." }
+            Start-Process -FilePath $dockerDesktop -WindowStyle Hidden | Out-Null
+        }
         $dockerDeadline = (Get-Date).AddSeconds(120)
         while ((Get-Date) -lt $dockerDeadline) {
             if (Test-DockerReady $dockerContext) {
+                $dockerReady = $true
                 break
             }
             Start-Sleep -Seconds 3
         }
     }
-    if (-not (Test-DockerReady $dockerContext)) { throw "Docker engine is not ready." }
+    if (-not $dockerReady) { throw "Docker engine is not ready." }
 
     $composeStarted = $true
     & docker compose -p $projectName -f $composeFile up -d
@@ -176,9 +180,24 @@ try {
         -PassThru
     Wait-Http "http://127.0.0.1:8080/api/articles/latest?page=0&size=1" 180
 
-    $fixture = Get-Content (Join-Path $frontendPath "e2e/fixtures/full-stack-smoke.sql") -Raw -Encoding utf8
-    $fixture | & docker compose -p $projectName -f $composeFile exec -T mysql mysql --default-character-set=utf8mb4 -uroot -pe2epw globaltimes
+    $fixturePath = Join-Path $frontendPath "e2e/fixtures/full-stack-smoke.sql"
+    & docker compose -p $projectName -f $composeFile cp $fixturePath mysql:/tmp/full-stack-smoke.sql
+    if ($LASTEXITCODE -ne 0) { throw "Failed to copy E2E fixture." }
+    & docker compose -p $projectName -f $composeFile exec -T mysql sh -c "mysql --default-character-set=utf8mb4 -uroot -pe2epw globaltimes < /tmp/full-stack-smoke.sql"
     if ($LASTEXITCODE -ne 0) { throw "Failed to load E2E fixture." }
+
+    $translationFixturePath = Join-Path $frontendPath "e2e/fixtures/redis-translations.json"
+    $translationFixtures = Get-Content $translationFixturePath -Raw -Encoding utf8 | ConvertFrom-Json
+    foreach ($translationFixture in $translationFixtures) {
+        $setResult = (& docker compose -p $projectName -f $composeFile exec -T redis redis-cli SETEX $translationFixture.key 3600 $translationFixture.value) -join ""
+        if ($LASTEXITCODE -ne 0 -or $setResult.Trim() -ne "OK") {
+            throw "Failed to load Redis translation fixture."
+        }
+        $cachedTranslation = (& docker compose -p $projectName -f $composeFile exec -T redis redis-cli GET $translationFixture.key) -join ""
+        if ($LASTEXITCODE -ne 0 -or $cachedTranslation.Trim() -ne $translationFixture.value) {
+            throw "Redis translation fixture verification failed."
+        }
+    }
 
     $npmCommand = if ($onWindows) { "npm.cmd" } else { "npm" }
     $frontendProcess = Start-Process -FilePath $npmCommand `
@@ -201,6 +220,11 @@ try {
         if ($LASTEXITCODE -ne 0) { throw "Playwright E2E failed." }
     } finally {
         Pop-Location
+    }
+
+    $perspectivesCacheExists = (& docker compose -p $projectName -f $composeFile exec -T redis redis-cli EXISTS "perspectives:article:990102") -join ""
+    if ($LASTEXITCODE -ne 0 -or $perspectivesCacheExists.Trim() -ne "1") {
+        throw "Perspectives cache was not created by the E2E flow."
     }
 } finally {
     Stop-Tree $frontendProcess


### PR DESCRIPTION
## 📌 작업 내용

- 한국·미국·일본의 동일 이슈 기사와 언론사 MySQL fixture를 추가했습니다.
- Redis 고정 번역 fixture로 실제 Backend `TranslationService` cache hit를 사용하면서 Google Translation API 호출과 비용을 차단했습니다.
- 검색 입력 → `/api/search` → MySQL FULLTEXT 원문·번역어 결과를 검증하는 Playwright 시나리오를 추가했습니다.
- 기사 상세 → 실제 `/api/news/{id}/perspectives` → 국가별 기사 UI와 관련 기사 상세 이동을 검증합니다.
- 동일 Perspectives API 재요청과 Redis `perspectives:article:990102` key 생성으로 warm cache 경로를 확인합니다.
- Windows PowerShell stdin의 한글 SQL 손상을 방지하도록 `docker compose cp` 후 container 내부 mysql client로 fixture를 적재합니다.
- Docker probe가 순간 실패해도 Windows·Linux 모두 최대 120초 bounded readiness retry 후 판정하도록 보완했습니다.
- 기존 기사 상세·익명 SSE·인증 스크랩·채팅 시나리오와 함께 회귀 검증합니다.

## ✅ 체크리스트
- [x] MySQL UTF-8 fixture 원문 보존 확인
- [x] Redis 번역 fixture SETEX 후 값 재조회 확인
- [x] 다국어 검색 응답의 원문·번역어와 한국·미국·일본 기사 확인
- [x] 실제 Perspectives 국가 그룹·warm 재조회·Redis cache key 확인
- [x] 관련 기사 카드의 실제 상세 이동 확인
- [x] Playwright 3개 시나리오 통과 (`13.6s`)
- [x] Full-stack orchestration 및 cleanup 완료 (`71.0s`)
- [x] Vite Production build 통과
- [x] 신규 E2E ESLint, PowerShell parser, `git diff --check` 통과
- [x] 최초 Runner의 일시적 Docker readiness 실패 원인 반영
- [x] 최종 HEAD `b497292` GitHub Full Stack E2E 성공 (`1m 32s`, run `31524168174`)
- [x] 로컬 확인 완료
- [x] BE 연동 확인 완료

## 🔍 Reviewer 확인 요청

- 고정 번역 fixture가 실제 Backend cache 경로를 통과하면서 외부 Google API를 확실히 차단하는지
- SQL fixture의 UTF-8 전달 방식과 container 경계가 Windows/Linux 모두 안전한지
- 검색·FULLTEXT·Perspectives·Redis cache 검증이 Mock 응답으로 대체되지 않았는지
- Playwright locator와 warm cache 검증이 우연한 UI 중복이나 기존 상태에 의존하지 않는지
- Docker bounded readiness retry와 기존 container cleanup을 회귀시키지 않는지

## 🔗 관련 이슈

Closes #102
