### PR TITLE
🧹 [REFACTOR/#104] Frontend ESLint 품질 기준선 정상화

### DIFF
--- a/FrontEnd/src/App.jsx
+++ b/FrontEnd/src/App.jsx
@@ -1,6 +1,6 @@
 import { BrowserRouter } from 'react-router-dom';
 import Routes from './router/Routers';
-import { LanguageProvider } from './util/LanguageContext.jsx';
+import { LanguageProvider } from './util/LanguageProvider.jsx';
 import { AuthProvider } from './util/AuthContext.jsx';
 
 function App() {

--- a/FrontEnd/src/api/TranslatedText.jsx
+++ b/FrontEnd/src/api/TranslatedText.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import PropTypes from "prop-types";
 import { useLanguage } from "../util/LanguageContext";
 import axios from "axios";
 import { DEFAULT_UI_LANGUAGE } from "../constants/uiLanguage.js";
@@ -94,6 +95,10 @@ const TranslatedText = ({ text }) => {
     }, [language, text]);
 
     return <>{translated}</>;
+};
+
+TranslatedText.propTypes = {
+    text: PropTypes.string,
 };
 
 export default TranslatedText;

--- a/FrontEnd/src/components/commons/header/LanguageSelect.jsx
+++ b/FrontEnd/src/components/commons/header/LanguageSelect.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import PropTypes from "prop-types";
 import styles from "./LanguageSelect.module.css";
 
 const LANGUAGES = [
@@ -81,3 +82,10 @@ export default function LanguageSelect({ value, onChange, isHome, isMobile = fal
     </div>
   );
 }
+
+LanguageSelect.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+  isHome: PropTypes.bool,
+  isMobile: PropTypes.bool,
+};

--- a/FrontEnd/src/components/detailsPage/Sidebar.jsx
+++ b/FrontEnd/src/components/detailsPage/Sidebar.jsx
@@ -1,4 +1,5 @@
 import styles from "./Sidebar.module.css";
+import PropTypes from "prop-types";
 import { useNavigate } from "react-router-dom";
 import { Bars } from "react-loader-spinner";
 
@@ -73,3 +74,15 @@ export default function Sidebar({ recentNewsList }) {
     </div>
   );
 }
+
+Sidebar.propTypes = {
+  recentNewsList: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      sourceName: PropTypes.string.isRequired,
+      title: PropTypes.string.isRequired,
+      urlToImage: PropTypes.string,
+      publishedAt: PropTypes.string,
+    }),
+  ),
+};

--- a/FrontEnd/src/components/intro/top/IntroTopAnimation.jsx
+++ b/FrontEnd/src/components/intro/top/IntroTopAnimation.jsx
@@ -1,4 +1,5 @@
 import { motion } from "framer-motion";
+import PropTypes from "prop-types";
 import styles from "./IntroTop.module.css";
 import { useTranslatedLabel } from "../../../hooks/useTranslatedLabel.js";
 
@@ -39,3 +40,11 @@ export default function IntroAnimation({ isVisible, title, description, imgSrc, 
       </motion.div>
     );
   }
+
+IntroAnimation.propTypes = {
+    isVisible: PropTypes.bool.isRequired,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    imgSrc: PropTypes.string.isRequired,
+    isMobile: PropTypes.bool.isRequired,
+};

--- a/FrontEnd/src/components/mainPage/ExploreDatePicker.jsx
+++ b/FrontEnd/src/components/mainPage/ExploreDatePicker.jsx
@@ -55,7 +55,7 @@ export default function ExploreDatePicker({
     if (selectedDate) {
       setView(new Date(selectedDate.getFullYear(), selectedDate.getMonth(), 1));
     }
-  }, [value]);
+  }, [selectedDate]);
 
   const displayText = selectedDate
     ? selectedDate.toLocaleDateString("ko-KR", {

--- a/FrontEnd/src/components/mainPage/SearchNews.jsx
+++ b/FrontEnd/src/components/mainPage/SearchNews.jsx
@@ -5,7 +5,7 @@ import SearchNewsCard from '../newsCard/SearchNewsCard';
 import TranslatedText from '../../api/TranslatedText';
 
 
-export default function SearchNews({ searchResults = [], originalText="", translatedText = "", searchTerm }) {
+export default function SearchNews({ searchResults = [], originalText="", translatedText = "" }) {
 
     return(
         <div className={styled['SearchNews--container']}>
@@ -49,7 +49,6 @@ SearchNews.propTypes = {
     ).isRequired,
     originalText: PropTypes.string.isRequired,
     translatedText: PropTypes.string.isRequired,
-    searchTerm: PropTypes.string.isRequired,
 };
 
 

--- a/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/ScrapNewsCard.jsx
@@ -8,7 +8,7 @@ import { useTranslatedLabel } from '../../hooks/useTranslatedLabel.js';
 import { toggleScrap as toggleScrapAPI } from '../../api/scrapAPI';
 import { FaBookmark, FaTimes } from 'react-icons/fa';
 
-export default function ScrapNewsCard({ id, press, title, summary, image, year, month, day, isScrapped, setIsScrapped }) {
+export default function ScrapNewsCard({ id, press, title, summary, image, year, month, day, setIsScrapped }) {
     const articleId = id;
     const { token } = useAuth();
     const navigate = useNavigate();
@@ -122,7 +122,6 @@ ScrapNewsCard.propTypes = {
     year: PropTypes.string.isRequired,
     month: PropTypes.string.isRequired,
     day: PropTypes.string.isRequired,
-    isScrapped: PropTypes.bool,
     setIsScrapped: PropTypes.func.isRequired,
 };
 

--- a/FrontEnd/src/components/newsCard/SearchNewsCard.jsx
+++ b/FrontEnd/src/components/newsCard/SearchNewsCard.jsx
@@ -37,7 +37,7 @@ export default function SearchNewsCard({ id, press, title, summary, image, year,
             setTranslatedKeyword(translatedKeyword_);
         }
         getTranslation();
-    }, [language, id])
+    }, [language, id, title, summary, translatedText])
 
     function highlightText(text, keyword, originalKeyword) {
         // console.log("keyword"+keyword);

--- a/FrontEnd/src/pages/OAuthCallbackPage.jsx
+++ b/FrontEnd/src/pages/OAuthCallbackPage.jsx
@@ -18,7 +18,7 @@ export default function OAuthCallbackPage() {
       // 토큰 없으면 메인으로
       navigate("/", { replace: true });
     }
-  }, []);
+  }, [login, navigate]);
 
   return (
     <div style={{ display: "flex", justifyContent: "center", alignItems: "center", height: "100vh" }}>

--- a/FrontEnd/src/pages/ScrapPage.jsx
+++ b/FrontEnd/src/pages/ScrapPage.jsx
@@ -103,7 +103,6 @@ export default function ScrapPage() {
                     year={news.year}
                     month={news.month}
                     day={news.day}
-                    isScrapped={isScrapped}
                     setIsScrapped={setIsScrapped}
                   />
                 ))}

--- a/FrontEnd/src/pages/SearchPage.jsx
+++ b/FrontEnd/src/pages/SearchPage.jsx
@@ -70,9 +70,8 @@ export default function SearchPage() {
             ) : searchError ? (
                 <ApiErrorMessage message={searchError} />
             ) : searchResults?.length > 0 ? (
-                <SearchNews 
-                    searchTerm={searchTerm} 
-                    searchResults={searchResults} 
+                <SearchNews
+                    searchResults={searchResults}
                     originalText={originalWord}
                     translatedText={translatedWord}
                 />

--- a/FrontEnd/src/util/AuthContext.jsx
+++ b/FrontEnd/src/util/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useCallback, useContext, useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { authAPI } from "../api/authAPI";
 import { AUTH_EXPIRED_EVENT } from "../api/apiClient";
@@ -9,6 +9,18 @@ const AuthContext = createContext();
 export const AuthProvider = ({ children }) => {
   const [token, setToken] = useState(localStorage.getItem("token") || null);
   const [user, setUser] = useState(null);
+
+  const login = useCallback((newToken) => {
+    clearAnonymousSessionId();
+    localStorage.setItem("token", newToken);
+    setToken(newToken);
+  }, []);
+
+  const logout = useCallback(() => {
+    localStorage.removeItem("token");
+    setToken(null);
+    setUser(null);
+  }, []);
 
   useEffect(() => {
     const handleExpired = () => {
@@ -29,19 +41,7 @@ export const AuthProvider = ({ children }) => {
           logout();
         });
     }
-  }, [token]);
-
-  const login = (newToken) => {
-    clearAnonymousSessionId();
-    localStorage.setItem("token", newToken);
-    setToken(newToken);
-  };
-
-  const logout = () => {
-    localStorage.removeItem("token");
-    setToken(null);
-    setUser(null);
-  };
+  }, [token, logout]);
 
   return (
     <AuthContext.Provider value={{ token, user, login, logout, isLoggedIn: !!token }}>

--- a/FrontEnd/src/util/LanguageContext.jsx
+++ b/FrontEnd/src/util/LanguageContext.jsx
@@ -1,18 +1,6 @@
-import { createContext, useContext, useState } from "react";
-import { DEFAULT_UI_LANGUAGE } from "../constants/uiLanguage.js";
+import { createContext, useContext } from "react";
 
-const LanguageContext = createContext();
-
-export const LanguageProvider = ({ children }) => {
-  const [language, setLanguage] = useState(DEFAULT_UI_LANGUAGE);
-  // console.log(language);
-
-  return (
-    <LanguageContext.Provider value={{ language, setLanguage }}>
-      {children}
-    </LanguageContext.Provider>
-  );
-};
+export const LanguageContext = createContext();
 
 export function useLanguage() {
   return useContext(LanguageContext);

--- a/FrontEnd/src/util/LanguageProvider.jsx
+++ b/FrontEnd/src/util/LanguageProvider.jsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { DEFAULT_UI_LANGUAGE } from "../constants/uiLanguage.js";
+import { LanguageContext } from "./LanguageContext.jsx";
+
+export const LanguageProvider = ({ children }) => {
+  const [language, setLanguage] = useState(DEFAULT_UI_LANGUAGE);
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+LanguageProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -13,7 +13,24 @@
 
 ## In Progress
 
-- 없음
+### #104 Frontend ESLint 오류·경고 해소 및 품질 기준선 정상화
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/issues/104
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/pull/105
+- 목적: 기존 ESLint 위반을 해소해 이후 PR 단위 Build·Lint 자동 검증을 적용할 수 있는 정적 분석 기준선을 만듭니다.
+- 초기 기준선: 전체 ESLint `17 errors / 4 warnings`
+- Overengineering 판단: ESLint 메이저 업그레이드나 신규 규칙 도입 없이 기존 설정에서 확인된 위반만 해소합니다.
+- 변경 범위:
+  - 번역·언어 선택·최근 기사·인트로 컴포넌트의 PropTypes 계약 보완
+  - 검색·스크랩 컴포넌트의 사용하지 않는 props와 호출부 전달값 제거
+  - 날짜 선택·검색 카드 번역·OAuth callback effect 의존성 정합화
+  - 인증 함수를 `useCallback`으로 안정화하고 Language context와 Provider 책임 분리
+- 검증 결과:
+  - 전체 ESLint `17 errors / 4 warnings → 0` (`--max-warnings 0` 통과)
+  - Vite 7 Production build 통과 (`2,339 modules`, `34.72s`)
+  - `git diff --check` 통과
+  - 로컬 Full Stack E2E는 Docker Desktop 기동 후 Engine이 120초 내 준비되지 않아 환경 사유로 보류
+  - PR `full-stack-e2e` 라벨을 통해 GitHub Ubuntu Runner 재검증 예정
 
 ## Recently Merged
 


### PR DESCRIPTION
## 📌 작업 내용

- Frontend 전체 ESLint 기준선의 PropTypes 누락과 사용하지 않는 props를 정리했습니다.
- 날짜 선택, 검색 카드 번역, OAuth callback effect의 의존성을 실제 참조값과 일치시켰습니다.
- OAuth callback이 안정된 함수 참조를 의존하도록 인증 함수를 `useCallback`으로 고정했습니다.
- Fast Refresh 경고의 원인이던 Language context와 Provider export 책임을 분리했습니다.
- ESLint 규칙 비활성화나 라이브러리 메이저 업그레이드 없이 기존 `17 errors / 4 warnings`를 0건으로 해소했습니다.
- 조사·판단·검증 결과를 `docs/frontend-improvement/WORK_PROGRESS.md`에 같은 커밋으로 기록했습니다.

### Overengineering 판단

- 신규 도구나 규칙을 추가하지 않고 기존 ESLint 설정에서 확인된 위반만 해소했습니다.
- 번들 크기 경고와 ESLint/React 메이저 업그레이드는 별도 근거가 필요한 후속 범위로 제외했습니다.

### 검증

- `npm.cmd run lint` 통과 (`17 errors / 4 warnings → 0`)
- `npm.cmd run build` 통과 (Vite 7, 2,339 modules, 34.72s)
- `git diff --check` 통과
- 로컬 Full Stack E2E는 Docker Desktop Engine이 120초 내 준비되지 않아 환경 사유로 보류했습니다.
- `full-stack-e2e` 라벨로 GitHub Ubuntu Runner에서 동일한 Backend 연동 시나리오를 재검증합니다.

## ✅ 체크리스트
- [x] 로컬 확인 완료
- [ ] BE 연동 확인 완료

## 🔗 관련 이슈
Closes #104
