### PR TITLE
⚙️ [CI/#106] Frontend Build·Lint PR 자동 검증 구축

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,41 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: frontend-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: FrontEnd
+
+    steps:
+      - name: Checkout Frontend
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20.19.0"
+          cache: npm
+          cache-dependency-path: FrontEnd/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Build production bundle
+        run: npm run build

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -13,7 +13,23 @@
 
 ## In Progress
 
-- 없음
+### #106 Frontend Build·Lint PR 자동 검증 구축
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/issues/106
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/pull/107
+- 목적: #104에서 정상화한 ESLint 기준선과 production build를 모든 `develop` 대상 PR에서 자동 검증합니다.
+- 기존 상태: Full Stack E2E는 라벨 또는 수동 실행 방식이며, Backend와 독립된 기본 Frontend PR check는 없습니다.
+- Overengineering 판단: 신규 도구 없이 기존 npm scripts와 GitHub Actions를 재사용하고 Docker·Backend·Playwright·배포는 제외합니다.
+- 구현 범위:
+  - Node `20.19.0`, npm cache, `npm ci` 기반 재현 가능한 의존성 설치
+  - `npm run lint`와 `npm run build` 순차 실행
+  - `contents: read` 최소 권한과 10분 timeout 적용
+  - 동일 PR의 이전 실행을 취소하는 concurrency 설정
+- 검증 결과:
+  - 로컬 전체 ESLint 통과 (`0 errors / 0 warnings`)
+  - Vite 7 Production build 통과 (`2,339 modules`, `20.41s`)
+  - `git diff --check` 통과
+  - PR 생성 후 신규 `Frontend CI` workflow의 실제 GitHub Ubuntu Runner 성공 확인 예정
 
 ## Recently Merged
 


### PR DESCRIPTION
## 📌 작업 내용

- 모든 `develop` 대상 PR과 수동 실행에서 동작하는 `Frontend CI` workflow를 추가했습니다.
- Node `20.19.0`과 npm cache를 사용해 `npm ci → npm run lint → npm run build`를 순차 검증합니다.
- `contents: read` 최소 권한과 10분 timeout을 적용했습니다.
- 동일 PR에 새 commit이 push되면 이전 실행을 취소하도록 concurrency를 설정했습니다.
- Backend·Docker·Playwright가 필요한 opt-in Full Stack E2E와 Frontend 기본 CI의 책임을 분리했습니다.
- 조사·판단·검증 결과를 `docs/frontend-improvement/WORK_PROGRESS.md`에 같은 커밋으로 기록했습니다.

### Overengineering 판단

- 신규 도구나 테스트 프레임워크 없이 기존 npm scripts와 GitHub Actions만 재사용했습니다.
- Full Stack E2E 통합, 배포, branch protection 강제는 별도 운영 판단이 필요한 범위로 제외했습니다.

### 검증

- 로컬 `npm.cmd run lint` 통과 (`0 errors / 0 warnings`)
- 로컬 `npm.cmd run build` 통과 (Vite 7, 2,339 modules, 20.41s)
- `git diff --check` 통과
- PR에서 신규 `Frontend CI` GitHub Runner 실행 결과 확인 예정

## ✅ 체크리스트
- [x] 로컬 확인 완료
- [x] BE 연동 확인 완료 (Backend 비의존 workflow)

## 🔗 관련 이슈
Closes #106
