### PR TITLE
🧪 [TEST/#108] 공개 기사 탐색·비로그인 스크랩 연동 E2E

### DIFF
--- a/FrontEnd/e2e/fixtures/full-stack-smoke.sql
+++ b/FrontEnd/e2e/fixtures/full-stack-smoke.sql
@@ -124,7 +124,7 @@ INSERT INTO article (
   'US',
   'This second article verifies client-side detail navigation.',
   'Second article description for the full-stack E2E smoke test.',
-  '2026-08-11 11:00:00',
+  CURRENT_TIMESTAMP - INTERVAL 1 HOUR,
   'The second article summary passed through the real backend.',
   'Second full-stack E2E article',
   'https://example.com/e2e/full-stack-97',
@@ -135,5 +135,6 @@ INSERT INTO article (
 )
 ON DUPLICATE KEY UPDATE
   crawled_content = VALUES(crawled_content),
+  published_at = VALUES(published_at),
   summary = VALUES(summary),
   title = VALUES(title);

--- a/FrontEnd/e2e/public-browsing.spec.js
+++ b/FrontEnd/e2e/public-browsing.spec.js
@@ -1,0 +1,122 @@
+import { expect, test } from "@playwright/test";
+
+const ARTICLE_ID = 990_097;
+const ARTICLE_TITLE = "Second full-stack E2E article";
+
+test("공개 기사 탐색부터 비로그인 스크랩 조회까지 실제 Backend 경로를 검증한다", async ({
+  page,
+}) => {
+  test.setTimeout(60_000);
+
+  await page.addInitScript(() => {
+    window.localStorage.removeItem("token");
+    window.localStorage.removeItem("scrapIds");
+  });
+
+  await page.route("https://translation.googleapis.com/**", async (route) => {
+    const body = route.request().postDataJSON();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: { translations: [{ translatedText: body.q }] },
+      }),
+    });
+  });
+
+  await page.route("**/api/news/*/perspectives", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ isSuccess: true, message: "success", data: {} }),
+    });
+  });
+
+  const popularResponsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/articles/popular?page=0&size=6"),
+  );
+  const latestResponsePromise = page.waitForResponse((response) =>
+    response.url().includes("/api/articles/cursor?size=8"),
+  );
+
+  await page.goto("/main");
+
+  const [popularResponse, latestResponse] = await Promise.all([
+    popularResponsePromise,
+    latestResponsePromise,
+  ]);
+  expect(popularResponse.status()).toBe(200);
+  expect(latestResponse.status()).toBe(200);
+
+  const popularBody = await popularResponse.json();
+  const latestBody = await latestResponse.json();
+  expect(popularBody.data.content.map(({ id }) => id)).toContain(ARTICLE_ID);
+  expect(latestBody.data.articles.map(({ id }) => id)).toContain(ARTICLE_ID);
+  await expect(page.getByText(ARTICLE_TITLE, { exact: true }).first()).toBeVisible();
+
+  await page
+    .getByRole("button", { name: /탐색 조건 열기/ })
+    .click();
+  await page.getByRole("button", { name: "국가", exact: true }).click();
+  await page.getByRole("option", { name: "US", exact: true }).click();
+  await page.getByRole("button", { name: "카테고리", exact: true }).click();
+  await page.getByRole("option", { name: "technology", exact: true }).click();
+
+  const exploreResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.pathname === "/api/articles/explore" &&
+      url.searchParams.get("country") === "US" &&
+      url.searchParams.get("category") === "technology" &&
+      url.searchParams.get("size") === "12"
+    );
+  });
+  await page.getByRole("button", { name: "이 조건으로 보기" }).click();
+
+  const exploreResponse = await exploreResponsePromise;
+  expect(exploreResponse.status()).toBe(200);
+  const exploreBody = await exploreResponse.json();
+  expect(exploreBody.data.articles.map(({ id }) => id)).toEqual([ARTICLE_ID]);
+
+  const exploreSection = page.getByRole("region", { name: "탐색 결과" });
+  const exploreCard = exploreSection
+    .getByRole("button")
+    .filter({ hasText: ARTICLE_TITLE });
+  await expect(exploreCard).toBeVisible();
+
+  const detailResponsePromise = page.waitForResponse((response) =>
+    response.url().includes(`/api/news/detail?id=${ARTICLE_ID}`),
+  );
+  await exploreCard.click();
+  expect((await detailResponsePromise).status()).toBe(200);
+  await expect(page).toHaveURL(new RegExp(`/detail/${ARTICLE_ID}$`));
+
+  await page.getByRole("button", { name: "스크랩", exact: true }).click();
+  await page
+    .getByRole("button", { name: "스크랩", exact: true })
+    .first()
+    .click();
+  await expect(
+    page.getByRole("button", { name: "스크랩됨", exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(() => JSON.parse(localStorage.getItem("scrapIds") || "[]")),
+    )
+    .toEqual([ARTICLE_ID]);
+
+  const scrapResponsePromise = page.waitForResponse((response) => {
+    const url = new URL(response.url());
+    return (
+      url.pathname === "/api/scrap" &&
+      url.searchParams.getAll("id").includes(String(ARTICLE_ID))
+    );
+  });
+  await page.getByText("마이스크랩", { exact: true }).first().click();
+
+  const scrapResponse = await scrapResponsePromise;
+  expect(scrapResponse.status()).toBe(200);
+  const scrapBody = await scrapResponse.json();
+  expect(scrapBody.data.map(({ id }) => id)).toContain(ARTICLE_ID);
+  await expect(page.getByText(ARTICLE_TITLE, { exact: true })).toBeVisible();
+});

--- a/docs/frontend-improvement/WORK_PROGRESS.md
+++ b/docs/frontend-improvement/WORK_PROGRESS.md
@@ -13,7 +13,28 @@
 
 ## In Progress
 
-- 없음
+### #108 공개 기사 탐색·비로그인 스크랩 실제 Backend 연동 E2E
+
+- Issue: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/issues/108
+- PR: https://github.com/SKU-GlobalTimes/GlobalTimes_FE/pull/109
+- 목적: 공개 사용자의 메인 기사 탐색부터 비로그인 스크랩 목록 복원까지 실제 Frontend → Backend → MySQL 계약을 자동 검증합니다.
+- 기존 공백: 상세·익명 SSE, 인증 스크랩·채팅, 검색·Perspectives E2E는 있지만 인기·cursor 최신·Explore·비로그인 `/api/scrap`의 브라우저 검증은 없습니다.
+- Overengineering 판단: 기존 Playwright·MySQL fixture·Full Stack E2E orchestration만 확장하며 신규 Backend API·프레임워크·외부 API 실호출은 추가하지 않습니다.
+- 검증 범위:
+  - 메인 화면 `/api/articles/popular`와 `/api/articles/cursor` 실제 응답·카드 렌더링
+  - `US + technology` Explore UI 조작과 `/api/articles/explore` query·fixture 결과
+  - Explore 카드 상세 이동과 비로그인 localStorage 스크랩 저장
+  - 마이스크랩 진입 후 `/api/scrap` 실제 조회와 카드 복원
+- Mock 경계: UI 번역과 이 시나리오 범위 밖의 Perspectives만 Mock하며 기사 목록·Explore·상세·요약·스크랩은 실제 Backend 경로를 사용합니다.
+- 검증 결과:
+  - 전체 ESLint 통과 (`0 errors / 0 warnings`)
+  - Vite 7 Production build 통과 (`2,339 modules`, `21.20s`)
+  - 로컬 Full Stack E2E 4개 시나리오 통과 (브라우저 `39.4s`, 전체 orchestration `231.2s`)
+  - MySQL·Redis container와 network cleanup 완료
+  - 첫 sandbox 실행은 Docker named pipe 접근 거부로 readiness 실패했으며, 권한이 적용된 동일 스크립트 재실행으로 코드와 환경 원인을 분리해 통과
+  - Reviewer Blocking: popular API의 최근 30일 조건 때문에 고정 발행일 fixture가 만료되는 문제를 실행 시각 1시간 전 발행일과 재실행 갱신으로 보완
+  - Blocking 반영 후 로컬 Full Stack E2E 4개 재통과 (브라우저 `37.5s`, 전체 orchestration `167.2s`)
+  - GitHub Ubuntu Runner 검증 예정
 
 ## Recently Merged
 

--- a/docs/frontend-improvement/full-stack-e2e.md
+++ b/docs/frontend-improvement/full-stack-e2e.md
@@ -17,7 +17,7 @@ Playwright Chromium
 → MySQL 13306 / Redis 16379
 ```
 
-- 실제: Flyway migration, 기사 fixture 저장, 상세·요약 Controller/Service/Repository, SSE 처리, 익명 Redis 대화 저장·조회
+- 실제: Flyway migration, 기사 fixture 저장, 인기·cursor 최신·Explore·상세·요약·스크랩 Controller/Service/Repository, SSE 처리, 익명 Redis 대화 저장·조회
 - Mock: Gemini 응답과 브라우저 Google Translation
 - 실제 경로: Redis에 고정 번역 fixture를 넣은 Backend 다국어 검색, MySQL FULLTEXT, Perspectives 계산·Redis cache·국가별 기사 이동
 - 비활성: News API·RSS scheduler, OAuth, 실제 외부 API 호출
@@ -76,6 +76,14 @@ Compose project 이름은 실행 프로세스 ID를 포함해 실행별로 분�
 실제 Google OAuth 로그인은 외부 계정과 redirect 정책에 의존하므로 E2E 범위에서 제외한다. 대신 fixture 사용자와 실행 시점의 E2E `JWT_SECRET`으로 10분 유효 JWT를 생성한다. 저장소에는 완성된 token을 기록하지 않는다.
 
 브라우저가 localStorage의 token을 읽은 뒤 실제 Backend `JwtAuthenticationFilter`와 Security matcher를 통과한다. `/api/user/me` 인증, 기사 스크랩 저장과 `/api/user/scraps` 재조회, 로그인 AI SSE 질의, MySQL `chat_history` 조회와 채팅 히스토리 팝업 노출을 순서대로 검증한다. Gemini와 화면 번역 Mock 경계는 익명 시나리오와 동일하다.
+
+## 공개 기사 탐색·비로그인 스크랩 시나리오
+
+브라우저가 메인 화면에 진입하면 `/api/articles/popular?page=0&size=6`과 `/api/articles/cursor?size=8`의 실제 응답에 fixture 기사 ID가 포함되고 카드가 렌더링되는지 확인한다. 이후 사용자가 탐색 조건 UI에서 `US`와 `technology`를 선택해 `/api/articles/explore` query와 단일 fixture 결과를 검증한다.
+
+Backend 인기 기사 조회는 실행 시각 기준 최근 30일 기사만 대상으로 한다. 따라서 공개 탐색 fixture의 발행 시각은 적재 시점의 1시간 전으로 설정하고 재실행 시에도 갱신해, 고정 날짜 만료로 제품 회귀 없이 E2E가 실패하지 않도록 한다.
+
+Explore 카드에서 상세 화면으로 이동한 뒤 비로그인 스크랩을 선택하면 article ID가 localStorage `scrapIds`에 저장되는지 확인한다. 마이스크랩 화면은 이 ID를 `/api/scrap`에 전달하고 실제 MySQL 기사 데이터를 카드로 복원해야 한다. 이 시나리오에서 UI 번역과 Perspectives만 Mock하며 기사 목록·Explore·상세·요약·스크랩은 실제 Backend 경로를 사용한다.
 
 Windows에서는 E2E artifact 아래의 임시 Docker config와 Docker Desktop Linux named pipe를 사용해 사용자 전역 Docker config 권한과 context 전환에 의존하지 않는다. readiness probe는 숨김 process로 실행하며 각 probe는 5초 timeout 뒤 종료 완료를 기다리고 process handle을 dispose한다. Windows와 Linux 모두 전체 준비 대기를 2분으로 제한한 bounded retry를 사용해 Docker daemon의 일시적인 준비 지연은 흡수하되 console 창·process 누적이나 무한 대기는 방지한다.
 


### PR DESCRIPTION
## 📌 작업 내용

- 공개 사용자가 메인 화면에서 인기·cursor 최신 기사 fixture를 실제 Backend 응답으로 조회하고 카드 렌더링까지 확인하는 Playwright 시나리오를 추가했습니다.
- 탐색 조건 UI에서 `US + technology`를 선택해 `/api/articles/explore` query와 실제 MySQL 결과를 검증합니다.
- Explore 카드에서 상세 화면으로 이동하고, 비로그인 스크랩을 localStorage에 저장한 뒤 마이스크랩의 `/api/scrap` 조회로 카드를 복원합니다.
- 네트워크 응답의 status·fixture ID와 브라우저 UI를 함께 검증해 API 성공과 화면 연동 회귀를 동시에 확인합니다.
- 실제 경로와 Mock 경계, 로컬 검증 결과를 `WORK_PROGRESS.md`와 Full Stack E2E 문서에 같은 커밋으로 기록했습니다.

### 실제 경로와 Mock 경계

- 실제: 인기 기사, cursor 최신 기사, Explore, 상세, 저장된 요약, 비로그인 스크랩 조회, MySQL
- Mock: 브라우저 UI 번역, 이번 공개 탐색 범위 밖의 Perspectives
- 비활성: 실제 Gemini·Google Translation·News API·RSS scheduler

### Overengineering 판단

- 기존 Playwright·MySQL fixture·Full Stack E2E orchestration을 확장했습니다.
- 신규 Backend API, 테스트 프레임워크, 외부 API 실호출은 추가하지 않았습니다.
- Google Trends와 legacy API 정리는 후속 범위로 분리했습니다.

### 검증

- `npm.cmd run lint` 통과 (`0 errors / 0 warnings`)
- `npm.cmd run build` 통과 (Vite 7, 2,339 modules, 21.20s)
- 로컬 Full Stack E2E 4개 통과 (브라우저 39.4s, 전체 orchestration 231.2s)
- MySQL·Redis container와 network cleanup 완료
- `git diff --check` 통과
- GitHub Ubuntu Runner 검증 예정

## ✅ 체크리스트
- [x] 로컬 확인 완료
- [x] BE 연동 확인 완료

## 🔗 관련 이슈
Closes #108
